### PR TITLE
Rename backupfiles to $name_$date.$suffix

### DIFF
--- a/DKV2/filehelper.h
+++ b/DKV2/filehelper.h
@@ -9,6 +9,4 @@ void showFileInFolder(const QString &path);
 
 void printHtmlToPdf( QString html, QString fn);
 
-QString getDbFolder();
-
 #endif // FILEHELPER_H


### PR DESCRIPTION
I did have the issue on FreeBSD with ZFS as filesystem that the copy operation of the backups led to useless file dates where it's impossible for the user to distinguish when the backup was created. I've changed that by creating useful backup file names that already include the backup date in the filename, since "older" backups don't need to be moved/copied to other filenames.
This also led to less code on our side due to the mighty QT abstractions and the user doesn't have to check file dates on other OS when the backup was created.

By the way: When accepting pull requests, you could choose to "rebase" them onto the master branch. IMHO this helps to keep the history clean if the Pull Request only includes one or two "atomic" commits. 