### PR TITLE
CI: Use ubuntu 18.04 in linux builds

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -12,8 +12,7 @@ on:
 
 jobs:
   build:
-    # Run on an older Ubuntu to make flatpack happy
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Check out


### PR DESCRIPTION
Ubuntu 16.04 is no longer available on Github Actions. This changes the build workflow to use Ubuntu 18.04 instead.

To actually enable the release builds on this Repo, @Schachigel would need to change the action permissions (https://github.com/Schachigel/DKV2/settings/actions -> change to "Allow all actions"). Until then, builds can be downloaded from [my fork](https://github.com/Frando/DKV2/releases)).