### PR TITLE
linux display problem of creditor/contract confirmation

### DIFF
--- a/DKV2/mainwindow.cpp
+++ b/DKV2/mainwindow.cpp
@@ -669,7 +669,7 @@ void MainWindow::on_comboUebersicht_currentIndexChanged(int i)
 void MainWindow::on_pbPrint_clicked()
 {   LOG_CALL;
     QString filename = appConfig::Outdir();
-    filename += qsl("\\") + QDate::currentDate().toString(qsl("yyyy-MM-dd_"));
+    filename += qsl("/") + QDate::currentDate().toString(qsl("yyyy-MM-dd_"));
     filename += Statistics_Filenames[ui->comboUebersicht->currentIndex()];
     filename += qsl(".pdf");
     QPdfWriter write(filename);

--- a/DKV2/uebersichten.cpp
+++ b/DKV2/uebersichten.cpp
@@ -225,7 +225,7 @@ steht die Einzahlung durch die Kreditgeber*in noch aus.
 void uebersichten::renderPayedInterestByYear()
 {   LOG_CALL;
     QString head {qsl("Ausgezahlte Zinsen pro Jahr")};
-    QString desc {qsl("Die Liste zeigt für jedes Jahr, welche Zinsen ausbezahlt oder, für thesaurierende Verträge und Verträge ohne Zinsauszahlung, angerechent wurden.")};
+    QString desc {qsl("Die Liste zeigt für jedes Jahr, welche Zinsen ausbezahlt oder, für thesaurierende Verträge und Verträge ohne Zinsauszahlung, angerechnet wurden.")};
     prep(head, desc);
     QVector<QSqlRecord> records;
     if( not executeSql( sqlInterestByYearOverview, QVariant(), records)) {
@@ -236,7 +236,7 @@ void uebersichten::renderPayedInterestByYear()
     tablelayout::section currentSec;
     QLocale locale;
     for( int i=0; i <records.count(); i++) {
-        QString year =records[i].value(qsl("Year")).toString();
+        QString year = records[i].value(qsl("Year")).toString();
         if( currentSec.header not_eq year) {
             // save complte section
             if( i not_eq 0) tl.sections.push_back(currentSec);
@@ -244,9 +244,16 @@ void uebersichten::renderPayedInterestByYear()
             currentSec.header =year;
             currentSec.data.clear();
         }
-        currentSec.data.push_back({ locale.toCurrencyString(records[i].value(qsl("Summe")).toDouble()),
-                                    records[i].value(qsl("BA")).toString(),
-                                    records[i].value(qsl("Thesa")).toString(),});
+
+        if (records[i].value(qsl("Summe")).toDouble() != 0.0) {
+            currentSec.data.push_back(
+                {
+                    qsl("    "),
+                    records[i].value(qsl("BA")).toString(),
+                        records[i].value(qsl("Thesa")).toString(),
+                        locale.toCurrencyString(records[i].value(qsl("Summe")).toDouble())
+                });
+        }
     }
     if( currentSec.data.count() or currentSec.header.count())
         tl.sections.push_back(currentSec);

--- a/DKV2/wizactivatecontract.cpp
+++ b/DKV2/wizactivatecontract.cpp
@@ -10,6 +10,11 @@
 wpInitialPayment_IntroPage::wpInitialPayment_IntroPage(QWidget* p) : QWizardPage(p)
 {
     setTitle(qsl("Aktivierung eines Vertrags"));
+    QVBoxLayout *layout = new QVBoxLayout;
+    subTitleLabel = new QLabel(qsl("Keine Daten!"));
+    subTitleLabel->setWordWrap(true);
+    layout->addWidget(subTitleLabel);
+    setLayout(layout);
 }
 
 void wpInitialPayment_IntroPage::initializePage()
@@ -17,20 +22,23 @@ void wpInitialPayment_IntroPage::initializePage()
     wizInitialPayment* wiz = qobject_cast<wizInitialPayment*>(wizard());
     QString subtitle = qsl("Mit dieser Dialogfolge kannst Du den Geldeingang zu Vertrag <p><b>%1</b> von <b>%2</b> <p>verbuchen. ");
     if( wiz->delayedInterest)
-        subtitle += qsl("Da für diesen Vertrag der Verzinsungsbeginn verzögert ist, muss dieser später eingegeben werden<br>");
+        subtitle += qsl("<p>Da für diesen Vertrag der Verzinsungsbeginn verzögert ist, muss dieser später eingegeben werden<br>");
     else
-        subtitle += qsl("Die Verzinsung für diesen Vertrag beginnt nach dem Geldeingang<br>");
-    setSubTitle(subtitle.arg(wiz->label, wiz->creditorName));
+        subtitle += qsl("<p>Die Verzinsung für diesen Vertrag beginnt nach dem Geldeingang<br>");
+    subTitleLabel->setText(subtitle.arg(wiz->label, wiz->creditorName));
 }
 
 QString fnDate {qsl("date")};
 wpInitialPayment_DatePage::wpInitialPayment_DatePage(QWidget* p) : QWizardPage(p)
 {
-    QDateEdit* de = new QDateEdit;
+    subTitleLabel = new QLabel(qsl("Keine Daten!"));
+    subTitleLabel->setWordWrap(true);
+    QDateEdit *de = new QDateEdit;
     de->setDisplayFormat(qsl("dd.MM.yyyy"));
     registerField(fnDate, de);
 
     QVBoxLayout*  layout = new QVBoxLayout;
+    layout->addWidget(subTitleLabel);
     layout->addWidget(de);
     setLayout(layout);
 }
@@ -38,7 +46,7 @@ wpInitialPayment_DatePage::wpInitialPayment_DatePage(QWidget* p) : QWizardPage(p
 void wpInitialPayment_DatePage::initializePage()
 {
     setTitle(qsl("Aktivierungsdatum"));
-    setSubTitle(qsl("Das Aktivierungsdatum entspricht dem Datum, zu dem das Geld auf unserem Konto eingegangen ist"));
+    subTitleLabel->setText(qsl("Das Aktivierungsdatum entspricht dem Datum, zu dem das Geld auf unserem Konto eingegangen ist"));
     wizInitialPayment* wiz = qobject_cast<wizInitialPayment*>(wizard());
     minDate = wiz->minimalActivationDate;
 }
@@ -57,14 +65,16 @@ QString fnAmount {qsl("amount")};
 wpInitialPayment_AmountPage::wpInitialPayment_AmountPage(QWidget* p) : QWizardPage(p)
 {
     setTitle(qsl("Eingegangener Kreditbetrag"));
-    setSubTitle(qsl("Gib die Summe ein, die von dem/der DK-Geber*in überwiesen wurde.<br> "
+    QLabel* subTitleLabel = new QLabel(qsl("Gib die Summe ein, die von dem/der DK-Geber*in überwiesen wurde.<p> "
                 "Diese entspricht normalerweise dem im Vertrag vereinbarten Kreditbetrag."));
-    QVBoxLayout*  layout = new QVBoxLayout;
+    subTitleLabel->setWordWrap(true);
+    QVBoxLayout *layout = new QVBoxLayout;
     QLabel* l = new QLabel(qsl("Betrag in Euro"));
     QLineEdit* le = new QLineEdit;
     registerField(fnAmount, le);
     le->setValidator(new QIntValidator(this));
     l->setBuddy(le);
+    layout->addWidget(subTitleLabel);
     layout->addWidget(l);
     layout->addWidget(le);
     setLayout(layout);
@@ -86,10 +96,12 @@ bool wpInitialPayment_AmountPage::validatePage()
 wpInitialPayment_SummaryPage::wpInitialPayment_SummaryPage( QWidget* p) : QWizardPage(p)
 {
     setTitle(qsl("Zusammenfassung"));
-    QCheckBox* cb = new QCheckBox(qsl("Die Eingaben sind korrekt!"));
+    subTitleLabel = new QLabel(qsl("Keine Daten!"));
+    QCheckBox *cb = new QCheckBox(qsl("Die Eingaben sind korrekt!"));
     registerField(qsl("confirmed"), cb);
     QVBoxLayout* layout = new QVBoxLayout;
-    layout-> addWidget(cb);
+    layout->addWidget(subTitleLabel);
+    layout->addWidget(cb);
     setLayout(layout);
     connect(cb, &QCheckBox::stateChanged, this, &wpInitialPayment_SummaryPage::onConfirmData_toggled);
 }
@@ -104,7 +116,7 @@ void wpInitialPayment_SummaryPage::initializePage()
     subt = subt.arg(wiz->label, wiz->creditorName, locale.toCurrencyString(amount), field(fnDate).toDate().toString(qsl("dd.MM.yyyy")));
     if( amount not_eq wiz->expectedAmount)
         subt += qsl(" <b><small>Der Überweisungsbetrag stimmt nicht mit dem Kreditbetrag überein.</small></b>");
-    setSubTitle(subt);
+    subTitleLabel->setText(subt);
 }
 
 bool wpInitialPayment_SummaryPage::validatePage()

--- a/DKV2/wizactivatecontract.h
+++ b/DKV2/wizactivatecontract.h
@@ -3,11 +3,15 @@
 
 #include <QDate>
 #include <QWizard>
+#include <QLabel>
 
 struct wpInitialPayment_IntroPage : public QWizardPage {
     wpInitialPayment_IntroPage(QWidget* w =nullptr);
     void initializePage() override;
     Q_OBJECT;
+
+private:
+    QLabel *subTitleLabel = nullptr;
 };
 
 extern QString fnDate;
@@ -18,6 +22,9 @@ struct wpInitialPayment_DatePage : public QWizardPage {
     bool validatePage() override;
     QDate minDate;
     Q_OBJECT;
+
+private:
+    QLabel *subTitleLabel = nullptr;
 };
 
 extern QString fnAmount;
@@ -37,8 +44,10 @@ public:
     bool isComplete() const override;
 public slots:
     void onConfirmData_toggled(int );
-};
 
+private:
+    QLabel *subTitleLabel = nullptr;
+};
 
 class wizInitialPayment : public QWizard
 {

--- a/DKV2/wizcancelcontract.cpp
+++ b/DKV2/wizcancelcontract.cpp
@@ -9,6 +9,11 @@
 wpCancelContract_IntroPage::wpCancelContract_IntroPage(QWidget* p) : QWizardPage(p)
 {
     setTitle(qsl("Vertragskündigung"));
+    subTitleLabel = new QLabel(qsl("Keine Daten!"));
+    subTitleLabel->setWordWrap(true);
+    QVBoxLayout *layout = new QVBoxLayout;
+    layout->addWidget(subTitleLabel);
+    setLayout(layout);
 }
 
 void wpCancelContract_IntroPage::initializePage()
@@ -18,17 +23,20 @@ void wpCancelContract_IntroPage::initializePage()
                      "<p>von <p><b>%2</b><p> kündigen. "
                      "Dadurch wird das Vertragsende festgelegt, an dem die Auszahlung erfolgen wird.<p>"));
     subTitle = subTitle.arg(wiz->c.label(), wiz->creditorName);
-    setSubTitle(subTitle);
+    subTitleLabel->setText(subTitle);
 }
 
 wpCancelContract_DatePage::wpCancelContract_DatePage(QWidget* p) : QWizardPage(p)
 {
     setTitle(qsl("Kündigungsdatum"));
+    subTitleLabel = new QLabel(qsl("Keine Daten!"));
+    subTitleLabel->setWordWrap(true);
 
-    QDateEdit* de = new QDateEdit;
+    QDateEdit *de = new QDateEdit;
     de->setDisplayFormat(qsl("dd.MM.yyyy"));
     registerField(qsl("date"), de);
     QVBoxLayout*  layout = new QVBoxLayout;
+    layout->addWidget(subTitleLabel);
     layout->addWidget(de);
     setLayout(layout);
 }
@@ -36,13 +44,13 @@ wpCancelContract_DatePage::wpCancelContract_DatePage(QWidget* p) : QWizardPage(p
 void wpCancelContract_DatePage::initializePage()
 {
     wizCancelContract* wiz = qobject_cast<wizCancelContract*>(wizard());
-    QString subTitle(qsl("Das durch die Kündigungsfrist vertraglich vereinbarte Vertragsende ist am <b>%1</b>.<br>"
-                         "Die letzte Buchung zu dem Vertrag war am <b>%2<b>.<br>"
-                     "<p>Gib das geplante Vertragsende ein."));
+    QString subTitle(qsl("Das durch die Kündigungsfrist vertraglich vereinbarte Vertragsende ist am <b>%1</b>.<p>"
+                         "Die letzte Buchung zu dem Vertrag war am <b>%2<b>.<p>"
+                     "Gib das geplante Vertragsende ein."));
     QDate latestB = wiz->c.latestBooking().date;
     subTitle =subTitle.arg(wiz->contractualEnd.toString(qsl("dd.MM.yyyy")), latestB.toString(qsl("dd.MM.yyyy")));
-    setSubTitle(subTitle);
-    setField(qsl("date"), std::max(wiz->contractualEnd, latestB).addDays(1));
+    subTitleLabel->setText(subTitle);
+    setField(qsl("date"), std::max(wiz->contractualEnd, latestB));
 }
 
 bool wpCancelContract_DatePage::validatePage()
@@ -63,10 +71,15 @@ bool wpCancelContract_DatePage::validatePage()
 wpCancelContract_SummaryPage::wpCancelContract_SummaryPage(QWidget* p) : QWizardPage(p)
 {
     setTitle(qsl("Zusammenfassung"));
-    QCheckBox* cb = new QCheckBox(qsl("Die Eingaben sind korrekt!"));
+    subTitleLabel = new QLabel(qsl("Keine Daten!"));
+    subTitleLabel->setWordWrap(true);
+
+    QCheckBox *cb = new QCheckBox(qsl("Die Eingaben sind korrekt!"));
     registerField(qsl("confirmed"), cb);
+
     QVBoxLayout* layout = new QVBoxLayout;
-    layout-> addWidget(cb);
+    layout->addWidget(subTitleLabel);
+    layout->addWidget(cb);
     setLayout(layout);
     connect(cb, &QCheckBox::stateChanged, this, &wpCancelContract_SummaryPage::onConfirmData_toggled);
 }
@@ -76,7 +89,7 @@ void wpCancelContract_SummaryPage::initializePage()
     QString subt =qsl("Der Vertrag <b>%1</b> <p>von <b>%2</b><p>soll zum <b>%3</b> beendet werden.");
     subt = subt.arg(wiz->c.label(), wiz->creditorName);
     subt = subt.arg(field(qsl("date")).toDate().toString(qsl("dd.MM.yyyy")));
-    setSubTitle(subt);
+    subTitleLabel->setText(subt);
 }
 void wpCancelContract_SummaryPage::onConfirmData_toggled(int)
 {

--- a/DKV2/wizcancelcontract.h
+++ b/DKV2/wizcancelcontract.h
@@ -2,6 +2,7 @@
 #define WIZCANCELCONTRACT_H
 
 #include <QWizard>
+#include <QLabel>
 
 #include "contract.h"
 
@@ -9,6 +10,9 @@ struct wpCancelContract_IntroPage : public QWizardPage {
     wpCancelContract_IntroPage (QWidget* w =nullptr);
     void initializePage() override;
     Q_OBJECT;
+
+private:
+    QLabel *subTitleLabel = nullptr;
 };
 
 struct wpCancelContract_DatePage : public QWizardPage {
@@ -17,6 +21,9 @@ struct wpCancelContract_DatePage : public QWizardPage {
     void initializePage() override;
     bool validatePage() override;
     Q_OBJECT;
+
+private:
+    QLabel *subTitleLabel = nullptr;
 };
 
 struct wpCancelContract_SummaryPage : public QWizardPage {
@@ -27,6 +34,7 @@ public slots:
     void onConfirmData_toggled(int);
 private:
     Q_OBJECT;
+    QLabel *subTitleLabel = nullptr;
 };
 
 struct wizCancelContract : public QWizard

--- a/DKV2/wizchangecontractvalue.cpp
+++ b/DKV2/wizchangecontractvalue.cpp
@@ -17,10 +17,14 @@
 wpChangeContract_IntroPage::wpChangeContract_IntroPage(QWidget* parent) : QWizardPage(parent)
 {
     setTitle(qsl("Ein- / Auszahlung"));
-    QRadioButton* rbDeposit = new QRadioButton(qsl("Einzahlung"));
+    subTitleLabel = new QLabel(qsl("Keine Daten!"));
+    subTitleLabel->setWordWrap(true);
+
+    QRadioButton *rbDeposit = new QRadioButton(qsl("Einzahlung"));
     QRadioButton* rbPayout = new QRadioButton(qsl("Auszahlung"));
     registerField(qsl("deposit_notPayment"), rbDeposit);
     QVBoxLayout* layout = new QVBoxLayout;
+    layout->addWidget(subTitleLabel);
     layout->addWidget(rbDeposit);
     layout->addWidget(rbPayout);
     setLayout(layout);
@@ -31,7 +35,7 @@ void wpChangeContract_IntroPage::initializePage()
     QString subtitle =qsl("In dieser Dialogfolge kannst Du Ein- oder Auszahlungen zum Vertrag <b>%1</b> von <b>%2</b> verbuchen.");
     wizChangeContract* wiz= qobject_cast<wizChangeContract*>(wizard());
     subtitle = subtitle.arg(wiz->contractLabel, wiz->creditorName);
-    setSubTitle(subtitle);
+    subTitleLabel->setText(subtitle);
 }
 
 bool wpChangeContract_IntroPage::validatePage()
@@ -55,10 +59,14 @@ bool wpChangeContract_IntroPage::validatePage()
 
 wpChangeContract_AmountPage::wpChangeContract_AmountPage(QWidget* parent) : QWizardPage(parent)
 {
-    QVBoxLayout*  layout = new QVBoxLayout;
+    subTitleLabel = new QLabel("Keine Daten!");
+    subTitleLabel->setWordWrap(true);
+
+    QVBoxLayout *layout = new QVBoxLayout;
     QLineEdit* le = new QLineEdit;
     registerField(qsl("amount"), le);
     le->setValidator(new QIntValidator(this));
+    layout->addWidget(subTitleLabel);
     layout->addWidget(le);
     setLayout(layout);
 }
@@ -73,7 +81,7 @@ void wpChangeContract_AmountPage::initializePage()
         setTitle(qsl("Einzahlungsbetrag"));
         QString subt =qsl("Gib den eingezahlten Betrag in ganzen Euro an. Der Betrag muss größer als %1 sein.");
         subt =subt.arg(l.toCurrencyString(minPayout));
-        setSubTitle(subt);
+        subTitleLabel->setText(subt);
 
         setField(qsl("amount"), 1000.);
     } else {
@@ -85,7 +93,7 @@ void wpChangeContract_AmountPage::initializePage()
         QLocale locale;
         QString subtitle =qsl("Der Auszahlungsbetrag kann zwischen %1 und %2 liegen.");
         subtitle = subtitle.arg(locale.toCurrencyString(minPayout), locale.toCurrencyString(maxPayout));
-        setSubTitle(subtitle);
+        subTitleLabel->setText(subtitle);
         setField(qsl("amount"), minPayout);
     }
 }
@@ -110,11 +118,15 @@ bool wpChangeContract_AmountPage::validatePage()
 
 wpChangeContract_DatePage::wpChangeContract_DatePage(QWidget* parent) : QWizardPage(parent)
 {
-    QDateEdit* de = new QDateEdit;
+    subTitleLabel = new QLabel(qsl("Keine Daten!"));
+    subTitleLabel->setWordWrap(true);
+
+    QDateEdit *de = new QDateEdit;
     de->setDisplayFormat(qsl("dd.MM.yyyy"));
     registerField(qsl("date"), de);
 
     QVBoxLayout*  layout = new QVBoxLayout;
+    layout->addWidget(subTitleLabel);
     layout->addWidget(de);
     setLayout(layout);
 }
@@ -127,10 +139,10 @@ void wpChangeContract_DatePage::initializePage()
     bool deposit = field(qsl("deposit_notPayment")).toBool();
     if( deposit) {
         setTitle(qsl("Datum des Geldeingangs"));
-        setSubTitle(subt + qsl("<p>Gib das Datum an, an dem das Geld auf unserem Konto gutgeschrieben wurde."));
+        subTitleLabel->setText(subt + qsl("<p>Gib das Datum an, an dem das Geld auf unserem Konto gutgeschrieben wurde."));
     } else {
         setTitle(qsl("Überweisungsdatum"));
-        setSubTitle(subt + qsl("<p>Gib das Datum ein, zu dem die Überweisung durchgeführt wird."));
+        subTitleLabel->setText(subt + qsl("<p>Gib das Datum ein, zu dem die Überweisung durchgeführt wird."));
     }
     setField(qsl("date"), wiz->earlierstDate);
 }
@@ -152,10 +164,14 @@ bool wpChangeContract_DatePage::validatePage()
 wpChangeContract_Summary::wpChangeContract_Summary(QWidget* p) : QWizardPage(p)
 {
     setTitle(qsl("Zusammenfassung"));
+    subTitleLabel = new QLabel("Keine Daten!");
+    subTitleLabel->setWordWrap(true);
+
     QCheckBox* cb = new QCheckBox(qsl("Die Eingaben sind korrekt!"));
     registerField(qsl("confirmed"), cb);
     QVBoxLayout* layout = new QVBoxLayout;
-    layout-> addWidget(cb);
+    layout->addWidget(subTitleLabel);
+    layout->addWidget(cb);
     setLayout(layout);
     connect(cb, &QCheckBox::stateChanged, this, &wpChangeContract_Summary::onConfirmData_toggled);
 }
@@ -180,7 +196,7 @@ void wpChangeContract_Summary::initializePage()
         newValue = wiz->currentAmount - change;
     }
     QLocale locale;
-    setSubTitle(subtitle.arg(wiz->contractLabel, wiz->creditorName, locale.toCurrencyString(oldValue),
+    subTitleLabel->setText(subtitle.arg(wiz->contractLabel, wiz->creditorName, locale.toCurrencyString(oldValue),
                    deposit? qsl("+") : qsl("-"), locale.toCurrencyString(change),
                    locale.toCurrencyString(newValue), field(qsl("date")).toDate().toString(qsl("dd.MM.yyyy"))));
 }

--- a/DKV2/wizchangecontractvalue.h
+++ b/DKV2/wizchangecontractvalue.h
@@ -3,6 +3,7 @@
 
 #include <QDate>
 #include <QWizard>
+#include <QLabel>
 
 class wpChangeContract_IntroPage : public QWizardPage
 {
@@ -11,6 +12,9 @@ public:
     void initializePage() override;
     bool validatePage() override;
     Q_OBJECT;
+
+private:
+    QLabel *subTitleLabel = nullptr;
 };
 
 struct wpChangeContract_AmountPage : public QWizardPage
@@ -20,6 +24,9 @@ struct wpChangeContract_AmountPage : public QWizardPage
     void initializePage() override;
     bool validatePage() override;
     Q_OBJECT;
+
+private:
+    QLabel *subTitleLabel = nullptr;
 };
 
 struct wpChangeContract_DatePage : public QWizardPage
@@ -29,6 +36,9 @@ struct wpChangeContract_DatePage : public QWizardPage
     void initializePage() override;
     bool validatePage() override;
     Q_OBJECT;
+
+private:
+    QLabel *subTitleLabel = nullptr;
 };
 
 class wpChangeContract_Summary : public QWizardPage{
@@ -39,6 +49,9 @@ public:
     bool isComplete() const override;
 public slots:
     void onConfirmData_toggled(int);
+
+private:
+    QLabel *subTitleLabel = nullptr;
 };
 
 struct wizChangeContract : public QWizard

--- a/DKV2/wiznew.cpp
+++ b/DKV2/wiznew.cpp
@@ -18,24 +18,28 @@
  * wizNewOrExistingPage - ask user if a new user should be created or an existing
  * one should be used
 */
-const QString pnNew {qsl("create_new")};
-const QString pnCreditor {qsl("creditor")};
+const QString pnNew{qsl("create_new")};
+const QString pnCreditor{qsl("creditor")};
 
-wpNewOrExisting::wpNewOrExisting(QWidget* p) : QWizardPage(p)
-{   LOG_CALL;
+wpNewOrExisting::wpNewOrExisting(QWidget *p) : QWizardPage(p)
+{
+    LOG_CALL;
     setTitle(qsl("Vertrag anlegen"));
-    setSubTitle(qsl("Mit dieser Dialogfolge kannst Du einen Kredigeber*in und Vertrag anlegen."));
-    rbNew =new QRadioButton(qsl("Neuen Kreditgeber*in anlegen"));
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("Mit dieser Dialogfolge kannst Du einen Kredigeber*in und Vertrag anlegen."));
+
+    rbNew = new QRadioButton(qsl("Neuen Kreditgeber*in anlegen"));
     rbNew->setToolTip(qsl("Wähle diese Option um einen Kreditgeber oder eine Kreditgeberin anzulegen. "
                           "Danach kannst Du die Eingabe beenden oder einen Vertrag anlegen."));
-    rbExisting =new QRadioButton(qsl("Existierenden Kreditgeber*in verwenden"));
+    rbExisting = new QRadioButton(qsl("Existierenden Kreditgeber*in verwenden"));
     rbExisting->setToolTip(qsl("Wähle diese Option um einen Vertrag zu einem bereits erfassten "
                                "Kreditgeber*in einzugeben."));
     registerField(pnNew, rbNew);
     cbCreditors = new QComboBox();
     cbCreditors->setToolTip(qsl("Wähle hier den Kreditgeber*in aus, für den der Vertrag angelegt werden soll."));
     registerField(pnCreditor, cbCreditors);
-    QVBoxLayout* l =new QVBoxLayout();
+    QVBoxLayout *l = new QVBoxLayout();
+    l->addWidget(subTitleLabel);
     l->addWidget(rbNew);
     l->addWidget(rbExisting);
     l->addWidget(cbCreditors);
@@ -43,38 +47,47 @@ wpNewOrExisting::wpNewOrExisting(QWidget* p) : QWizardPage(p)
     connect(rbExisting, &QAbstractButton::toggled, this, &wpNewOrExisting::onExistingCreditor_toggled);
 }
 void wpNewOrExisting::initializePage()
-{   LOG_CALL;
-    if( init) {
+{
+    LOG_CALL;
+    if (init)
+    {
         setField(pnNew, true);
         QList<QPair<int, QString>> Personen;
         cbCreditors->clear();
         KreditorenListeMitId(Personen);
-        if( Personen.count()) {
-            for(auto& Entry :qAsConst(Personen)) {
-                cbCreditors->addItem( Entry.second, QVariant((Entry.first)));
+        if (Personen.count())
+        {
+            for (auto &Entry : qAsConst(Personen))
+            {
+                cbCreditors->addItem(Entry.second, QVariant((Entry.first)));
             }
             rbExisting->setChecked(false);
             rbNew->setChecked(true);
             cbCreditors->setEnabled(false);
-        } else {
+        }
+        else
+        {
             rbNew->setChecked(true);
             cbCreditors->setEnabled(false);
             rbExisting->setEnabled(false);
         }
     }
-    init =false; // do not repeat after "back"
+    init = false; // do not repeat after "back"
 }
 void wpNewOrExisting::onExistingCreditor_toggled(bool b)
-{   LOG_CALL;
+{
+    LOG_CALL;
     cbCreditors->setEnabled(b);
 }
 bool wpNewOrExisting::validatePage()
-{   LOG_CALL;
+{
+    LOG_CALL;
 
-    if( field(pnNew).toBool())
+    if (field(pnNew).toBool())
         qInfo() << "User chose to create a new creditor";
-    else {
-        wizNew* wiz =qobject_cast<wizNew*> (wizard());
+    else
+    {
+        wizNew *wiz = qobject_cast<wizNew *>(wizard());
         wiz->creditorId = cbCreditors->itemData(field(pnCreditor).toInt()).toLongLong();
         creditor c(wiz->creditorId);
         setField(pnFName, c.firstname());
@@ -92,8 +105,9 @@ bool wpNewOrExisting::validatePage()
     return true;
 }
 int wpNewOrExisting::nextId() const
-{   LOG_CALL;
-    if( field(pnNew).toBool())
+{
+    LOG_CALL;
+    if (field(pnNew).toBool())
         return page_address;
     else
         return page_label_and_amount;
@@ -108,48 +122,58 @@ const QString pnCountry{qsl("country")};
 /*
  * wizNewCreditorAddressPage - ask address data for the new creditor
 */
-wpNewCreditorAddress::wpNewCreditorAddress(QWidget* p) : QWizardPage(p)
-{   LOG_CALL;
+wpNewCreditorAddress::wpNewCreditorAddress(QWidget *p) : QWizardPage(p)
+{
+    LOG_CALL;
     setTitle(qsl("Adresse"));
-    setSubTitle(qsl("Gib hier Namen und die Adressdaten ein."));
-    QLineEdit* leFirstName =new QLineEdit;
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("Gib hier Namen und die Adressdaten ein.<p>"));
+
+    QLineEdit *leFirstName = new QLineEdit;
     leFirstName->setToolTip(qsl("Die Felder für Vor- und Nachname dürfen nicht beide leer sein"));
     registerField(pnFName, leFirstName);
-    QLineEdit* leLastName =new QLineEdit;
+    QLineEdit *leLastName = new QLineEdit;
     registerField(pnLName, leLastName);
     leLastName->setToolTip(qsl("Die Felder für Vor- und Nachname dürfen nicht beide leer sein"));
-    QLineEdit* leStreet =new QLineEdit;
+    QLineEdit *leStreet = new QLineEdit;
     leStreet->setToolTip(qsl("Die Felder Straße, Postleitzahl und Stadt dürfen nicht leer sein"));
     registerField(pnStreet, leStreet);
-    QLineEdit* lePlz =new QLineEdit;
+    QLineEdit *lePlz = new QLineEdit;
     lePlz->setToolTip(qsl("Die Felder Straße, Postleitzahl und Stadt dürfen nicht leer sein"));
     registerField(pnPcode, lePlz);
-    QLineEdit* leCity =new QLineEdit;
+    QLineEdit *leCity = new QLineEdit;
     leCity->setToolTip(qsl("Die Felder Straße, Postleitzahl und Stadt dürfen nicht leer sein"));
     registerField(pnCity, leCity);
-    QLineEdit* leCountry =new QLineEdit;
+    QLineEdit *leCountry = new QLineEdit;
     leCountry->setToolTip(qsl("Trage hier ein Land ein, falls die Kreditor*in nicht in Deutschland wohnt"));
     registerField(pnCountry, leCountry);
 
-    QLabel* l1 =new QLabel(qsl("Name"));
-    QLabel* l2 =new QLabel(qsl("Straße"));
-    QLabel* l3 =new QLabel(qsl("Plz/Ort"));
-    QLabel* l4 =new QLabel(qsl("Land"));
+    QLabel *l1 = new QLabel(qsl("Name"));
+    QLabel *l2 = new QLabel(qsl("Straße"));
+    QLabel *l3 = new QLabel(qsl("Plz/Ort"));
+    QLabel *l4 = new QLabel(qsl("Land"));
 
-    QGridLayout* grid =new QGridLayout;
-    grid->addWidget(l1,          0, 0, 1, 1);
-    grid->addWidget(leFirstName, 0, 1, 1, 2);
-    grid->addWidget(leLastName,  0, 3, 1, 2);
+    QGridLayout *grid = new QGridLayout;
+    int row = 0;
+    grid->addWidget(subTitleLabel, row, 0, 1, 3);
 
-    grid->addWidget(l2,          1, 0, 1, 1);
-    grid->addWidget(leStreet,    1, 1, 1, 4);
+    row += 2;
+    grid->addWidget(l1, row, 0, 1, 1);
+    grid->addWidget(leFirstName, row, 1, 1, 2);
+    grid->addWidget(leLastName, row, 3, 1, 2);
 
-    grid->addWidget(l3,          2, 0, 1, 1);
-    grid->addWidget(lePlz,       2, 1, 1, 1);
-    grid->addWidget(leCity,      2, 2, 1, 3);
+    row++;
+    grid->addWidget(l2, row, 0, 1, 1);
+    grid->addWidget(leStreet, row, 1, 1, 4);
 
-    grid->addWidget(l4,          3, 0, 1, 1);
-    grid->addWidget(leCountry,   3, 1, 2, 1);
+    row++;
+    grid->addWidget(l3, row, 0, 1, 1);
+    grid->addWidget(lePlz, row, 1, 1, 1);
+    grid->addWidget(leCity, row, 2, 1, 3);
+
+    row++;
+    grid->addWidget(l4, row, 0, 1, 1);
+    grid->addWidget(leCountry, row, 1, 2, 1);
 
     grid->setColumnStretch(0, 1);
     grid->setColumnStretch(1, 2);
@@ -160,56 +184,65 @@ wpNewCreditorAddress::wpNewCreditorAddress(QWidget* p) : QWizardPage(p)
     setLayout(grid);
 }
 bool wpNewCreditorAddress::validatePage()
-{   LOG_CALL;
-    setField(pnFName,     field(pnFName).toString().trimmed());
-    setField(pnLName,     field(pnLName).toString().trimmed());
-    setField(pnStreet,    field(pnStreet)   .toString().trimmed());
-    setField(pnPcode,     field(pnPcode)    .toString().trimmed());
-    setField(pnCity,      field(pnCity)     .toString().trimmed());
-    setField(pnCountry,   field(pnCountry)  .toString().trimmed());
+{
+    LOG_CALL;
+    setField(pnFName, field(pnFName).toString().trimmed());
+    setField(pnLName, field(pnLName).toString().trimmed());
+    setField(pnStreet, field(pnStreet).toString().trimmed());
+    setField(pnPcode, field(pnPcode).toString().trimmed());
+    setField(pnCity, field(pnCity).toString().trimmed());
+    setField(pnCountry, field(pnCountry).toString().trimmed());
 
-    if( field(pnFName).toString().isEmpty()
-            &&
-            field(pnLName).toString().isEmpty())
+    if (field(pnFName).toString().isEmpty() &&
+        field(pnLName).toString().isEmpty())
         return false;
-    if( field(pnStreet).toString().isEmpty() ||
-            field(pnPcode).toString().isEmpty() ||
-            field(pnCity).toString().isEmpty())
+    if (field(pnStreet).toString().isEmpty() ||
+        field(pnPcode).toString().isEmpty() ||
+        field(pnCity).toString().isEmpty())
         return false;
     else
         return true;
 }
 int wpNewCreditorAddress::nextId() const
-{   LOG_CALL;
+{
+    LOG_CALL;
     return page_email;
 }
 
 /*
  * wizEmailPage - ask e-mail and comment for the new creditor
 */
-const QString pnEMail {qsl("e-mail")};
-const QString pnComment {qsl("comment")};
+const QString pnEMail{qsl("e-mail")};
+const QString pnComment{qsl("comment")};
 
-wpEmail::wpEmail(QWidget* p) : QWizardPage(p)
-{   LOG_CALL;
+wpEmail::wpEmail(QWidget *p) : QWizardPage(p)
+{
+    LOG_CALL;
     setTitle(qsl("E-mail"));
-    setSubTitle(qsl("Gib hier die E-Mail Adresse und eine Anmerkung an."));
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("Gib hier die E-Mail Adresse und eine Anmerkung an.<p>"));
 
-    QLabel* l1 =new QLabel(qsl("E-mail"));
-    QLineEdit* leEmail =new QLineEdit;
+    QLabel *l1 = new QLabel(qsl("E-mail"));
+    QLineEdit *leEmail = new QLineEdit;
     leEmail->setToolTip(qsl("Die E-Mail Adresse muss im gültigen Format vorliegen "
                             "(s. https://de.wikipedia.org/wiki/E-Mail-Adresse)."));
     registerField(pnEMail, leEmail);
-    QLabel* l2 =new QLabel(qsl("Anmerkung"));
-    QPlainTextEdit* eComment =new QPlainTextEdit;
+    QLabel *l2 = new QLabel(qsl("Anmerkung"));
+    QPlainTextEdit *eComment = new QPlainTextEdit;
     registerField(pnComment, eComment, "plainText", "textChanged");
     eComment->setToolTip(qsl("Es ist hilfreich in der Anmerkung den Kontakt "
                              "im Projekt oder sonstige Besonderheiten vermerken."));
-    QGridLayout* g =new QGridLayout;
-    g->addWidget(l1,      0, 0, 1, 1);
-    g->addWidget(leEmail, 0, 1, 1, 4);
-    g->addWidget(l2,      1, 0, 1, 1);
-    g->addWidget(eComment, 1, 1, 2, 4);
+    QGridLayout *g = new QGridLayout;
+    int row = 0;
+    g->addWidget(subTitleLabel, row, 0, 1, 4);
+
+    row += 2;
+    g->addWidget(l1, row, 0, 1, 1);
+    g->addWidget(leEmail, row, 1, 1, 4);
+
+    row++;
+    g->addWidget(l2, row, 0, 1, 1);
+    g->addWidget(eComment, row, 1, 2, 4);
     g->setColumnStretch(0, 1);
     g->setColumnStretch(1, 2);
     g->setColumnStretch(2, 2);
@@ -218,14 +251,16 @@ wpEmail::wpEmail(QWidget* p) : QWizardPage(p)
     setLayout(g);
 }
 bool wpEmail::validatePage()
-{   LOG_CALL;
-    QString email =field(pnEMail).toString().trimmed().toLower();
+{
+    LOG_CALL;
+    QString email = field(pnEMail).toString().trimmed().toLower();
     setField(pnEMail, email);
-    if( email.size())
+    if (email.size())
     {
         QRegularExpression rx(qsl("\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}\\b"),
                               QRegularExpression::CaseInsensitiveOption);
-        if( not rx.match(field(pnEMail).toString()).hasMatch()) {
+        if (not rx.match(field(pnEMail).toString()).hasMatch())
+        {
             QMessageBox::information(this, qsl("Fehler"), qsl("Das Format der e-mail Adresse ist ungültig: ") + email);
             return false;
         }
@@ -234,31 +269,35 @@ bool wpEmail::validatePage()
     return true;
 }
 int wpEmail::nextId() const
-{   LOG_CALL;
+{
+    LOG_CALL;
     return page_bankaccount;
 }
 
 /*
  * wpBankAccount - ask bank account data
 */
-const QString pnIban {qsl("iban")};
-const QString pnBic  {qsl("bic")};
-wpBankAccount::wpBankAccount(QWidget* p) : QWizardPage(p)
-{   LOG_CALL;
+const QString pnIban{qsl("iban")};
+const QString pnBic{qsl("bic")};
+wpBankAccount::wpBankAccount(QWidget *p) : QWizardPage(p)
+{
+    LOG_CALL;
     setTitle(qsl("Bankdaten"));
-    setSubTitle(qsl("Gib die Bankdaten der neuen Kreditor*in ein."));
-    QLabel* l1 =new QLabel(qsl("IBAN"));
-    QLineEdit* leIban =new QLineEdit;
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("Gib die Bankdaten der neuen Kreditor*in ein.<p>"));
+    QLabel *l1 = new QLabel(qsl("IBAN"));
+    QLineEdit *leIban = new QLineEdit;
     leIban->setToolTip(qsl("Es muss eine gültige IBAN eingegeben werden "
                            "(s. https://de.wikipedia.org/wiki/Internationale_Bankkontonummer)."));
     l1->setBuddy(leIban);
     registerField(pnIban, leIban);
-    QLabel* l2 =new QLabel(qsl("BIC <small>(optional)</small>"));
-    QLineEdit* leBic =new QLineEdit;
+    QLabel *l2 = new QLabel(qsl("BIC <small>(optional)</small>"));
+    QLineEdit *leBic = new QLineEdit;
     l2->setBuddy(leBic);
     registerField(pnBic, leBic);
 
-    QGridLayout* g =new QGridLayout;
+    QGridLayout *g = new QGridLayout;
+    g->addWidget(subTitleLabel);
     g->addWidget(l1);
     g->addWidget(leIban);
     g->addWidget(l2);
@@ -266,12 +305,16 @@ wpBankAccount::wpBankAccount(QWidget* p) : QWizardPage(p)
     setLayout(g);
 }
 bool wpBankAccount::validatePage()
-{   LOG_CALL;
-    QString formatedIban =field(pnIban).toString().trimmed();
-    QString iban =formatedIban.remove(' ');
-    if( iban.size()) {
-        IbanValidator iv; int pos =0;
-        if( iv.validate(iban, pos) not_eq IbanValidator::State::Acceptable) {
+{
+    LOG_CALL;
+    QString formatedIban = field(pnIban).toString().trimmed();
+    QString iban = formatedIban.remove(' ');
+    if (iban.size())
+    {
+        IbanValidator iv;
+        int pos = 0;
+        if (iv.validate(iban, pos) not_eq IbanValidator::State::Acceptable)
+        {
             QMessageBox::information(this, qsl("Fehler"), qsl("Die eingegebene Zeichenfolge ist keine gültige IBAN"));
             return false;
         }
@@ -281,31 +324,32 @@ bool wpBankAccount::validatePage()
     return true;
 }
 int wpBankAccount::nextId() const
-{   LOG_CALL;
+{
+    LOG_CALL;
     return page_confirm_creditor;
 }
 
 /*
  * wizConfirmCreditorData : ask if creditor data is OK and if a contract should be created
 */
-const QString pnConfirmCreditor {qsl("confirmCreateContract")};
-const QString pnCreateContract {qsl("createContract")};
+const QString pnConfirmCreditor{qsl("confirmCreateContract")};
+const QString pnCreateContract{qsl("createContract")};
 
-wpConfirmCreditor::wpConfirmCreditor(QWidget* p) : QWizardPage(p)
-{   LOG_CALL;
+wpConfirmCreditor::wpConfirmCreditor(QWidget *p) : QWizardPage(p)
+{
+    LOG_CALL;
     setTitle(qsl("Daten bestätigen"));
-    QCheckBox* cbConfirmCreditor =new QCheckBox(qsl("Die Angaben sind richtig!"));
+    QCheckBox *cbConfirmCreditor = new QCheckBox(qsl("Die Angaben sind richtig!"));
     cbConfirmCreditor->setToolTip(qsl("Du musst die Daten prüfen und ihre Richtigkeit "
                                       "bestätigen um sie speichern zu können."));
-    registerField(pnConfirmCreditor+qsl("*"), cbConfirmCreditor);
+    registerField(pnConfirmCreditor + qsl("*"), cbConfirmCreditor);
     cbConfirmCreditor->setChecked(false);
-    cbCreateContract =new QCheckBox(qsl("Im Anschluß Vertragsdaten eingeben"));
+    cbCreateContract = new QCheckBox(qsl("Im Anschluß Vertragsdaten eingeben"));
     cbCreateContract->setToolTip(qsl("Selektiere dieses Feld, um gleich einen neuen Vertrag anzulegen"));
     registerField(pnCreateContract, cbCreateContract);
     cbCreateContract->setChecked(true);
-    cbCreditorLabel = new QLabel(qsl("Keine Daten"));
-    QVBoxLayout* l =new QVBoxLayout;
-    l->addWidget(cbCreditorLabel); //
+    QVBoxLayout *l = new QVBoxLayout;
+    l->addWidget(subTitleLabel); //
     l->addWidget(cbConfirmCreditor);
     l->addWidget(cbCreateContract);
     setLayout(l);
@@ -313,66 +357,70 @@ wpConfirmCreditor::wpConfirmCreditor(QWidget* p) : QWizardPage(p)
     setCommitPage(true);
 }
 void wpConfirmCreditor::initializePage()
-{   LOG_CALL;
+{
+    LOG_CALL;
     QString creditorSummary{qsl("<table><tr><td>Name:</td><td><b>%1 %2</b><br></td></tr>"
                                 "<tr><td>Straße:</td><td>%3</td></tr>"
                                 "<tr><td>Plz/Ort:</td><td>%4</td></tr>"
                                 "<tr><td>E-Mail:</td><td>%5<br></td></tr>"
                                 "<tr><td>Kommentar:</td><td><small>%6<small></td></tr>"
                                 "<tr><td>Bankdaten:</td><td><table><tr><td>IBAN:</td><td>%7</td></tr><tr><td>BIC:</td><td>%8<td></tr></table></td></tr></table>")};
-    QString firstn =field(pnFName).toString().isEmpty() ? qsl("(kein Vorname)")  : field(pnFName).toString();
-    QString lastn  =field(pnLName).toString().isEmpty()  ? qsl("(kein Nachname)") : field(pnLName).toString();
-    QString street =field(pnStreet).toString().isEmpty()    ? qsl("(keine Strasse)") : field(pnStreet).toString();
+    QString firstn = field(pnFName).toString().isEmpty() ? qsl("(kein Vorname)") : field(pnFName).toString();
+    QString lastn = field(pnLName).toString().isEmpty() ? qsl("(kein Nachname)") : field(pnLName).toString();
+    QString street = field(pnStreet).toString().isEmpty() ? qsl("(keine Strasse)") : field(pnStreet).toString();
 
-    QString pcode  =field(pnPcode).toString().isEmpty()     ? qsl("(keine PLZ)")     : field(pnPcode).toString();
-    QString city   =field(pnCity).toString().isEmpty()      ? qsl("(keine Stadt)")   : field(pnCity).toString();
-    QString country =field(pnCountry).toString();
-    QString xxx = pcode +qsl(" ") +city;
-    if( not country.isEmpty())
-        xxx += qsl(" (") +country +qsl(")");
-    QString email  =field(pnEMail).toString().isEmpty()     ? qsl("(keine E-Mail Adresse)") :field(pnEMail).toString();
-    QString comment=field(pnComment).toString().isEmpty()   ? qsl("(keine Anmerkung)"): field(pnComment).toString();
-    QString iban   =field(pnIban).toString().isEmpty()      ? qsl("(keine IBAN)")     : field(pnIban).toString();
-    QString bic    =field(pnBic).toString().isEmpty()       ? qsl("(keine BIC)")      : field(pnBic).toString();
+    QString pcode = field(pnPcode).toString().isEmpty() ? qsl("(keine PLZ)") : field(pnPcode).toString();
+    QString city = field(pnCity).toString().isEmpty() ? qsl("(keine Stadt)") : field(pnCity).toString();
+    QString country = field(pnCountry).toString();
+    QString xxx = pcode + qsl(" ") + city;
+    if (not country.isEmpty())
+        xxx += qsl(" (") + country + qsl(")");
+    QString email = field(pnEMail).toString().isEmpty() ? qsl("(keine E-Mail Adresse)") : field(pnEMail).toString();
+    QString comment = field(pnComment).toString().isEmpty() ? qsl("(keine Anmerkung)") : field(pnComment).toString();
+    QString iban = field(pnIban).toString().isEmpty() ? qsl("(keine IBAN)") : field(pnIban).toString();
+    QString bic = field(pnBic).toString().isEmpty() ? qsl("(keine BIC)") : field(pnBic).toString();
 
-    cbCreditorLabel->setText(creditorSummary.arg(firstn, lastn, street, xxx,
-                                    email, comment, iban, bic));
-    wizNew* wiz =qobject_cast<wizNew*> (wizard());
-    if( wiz->selectCreateContract)
+    subTitleLabel->setText(creditorSummary.arg(firstn, lastn, street, xxx,
+                                                 email, comment, iban, bic));
+    wizNew *wiz = qobject_cast<wizNew *>(wizard());
+    if (wiz->selectCreateContract)
         cbCreateContract->setChecked(true);
     else
         cbCreateContract->setChecked(false);
 }
 bool wpConfirmCreditor::validatePage()
-{   LOG_CALL;
-    wizNew* wiz =qobject_cast<wizNew*> (wizard());
-    wiz->createCreditor =field(pnConfirmCreditor).toBool();
+{
+    LOG_CALL;
+    wizNew *wiz = qobject_cast<wizNew *>(wizard());
+    wiz->createCreditor = field(pnConfirmCreditor).toBool();
 
-    wiz->c_tor.setFirstname( wiz->field(pnFName).toString());
-    wiz->c_tor.setLastname(  wiz->field(pnLName).toString());
-    wiz->c_tor.setStreet(    wiz->field(pnStreet).toString());
+    wiz->c_tor.setFirstname(wiz->field(pnFName).toString());
+    wiz->c_tor.setLastname(wiz->field(pnLName).toString());
+    wiz->c_tor.setStreet(wiz->field(pnStreet).toString());
     wiz->c_tor.setPostalCode(wiz->field(pnPcode).toString());
-    wiz->c_tor.setCity(      wiz->field(pnCity).toString());
-    wiz->c_tor.setCountry(   wiz->field(pnCountry).toString());
-    wiz->c_tor.setEmail(     wiz->field(pnEMail).toString());
-    wiz->c_tor.setComment(   wiz->field(pnComment).toString());
-    wiz->c_tor.setIban(      wiz->field(pnIban).toString());
-    wiz->c_tor.setBic(       wiz->field(pnBic).toString());
+    wiz->c_tor.setCity(wiz->field(pnCity).toString());
+    wiz->c_tor.setCountry(wiz->field(pnCountry).toString());
+    wiz->c_tor.setEmail(wiz->field(pnEMail).toString());
+    wiz->c_tor.setComment(wiz->field(pnComment).toString());
+    wiz->c_tor.setIban(wiz->field(pnIban).toString());
+    wiz->c_tor.setBic(wiz->field(pnBic).toString());
 
     return true;
 }
 int wpConfirmCreditor::nextId() const
-{   LOG_CALL;
+{
+    LOG_CALL;
 
-    if( field(pnCreateContract).toBool())
+    if (field(pnCreateContract).toBool())
         return page_label_and_amount;
     else
         return -1;
 }
 void wpConfirmCreditor::onConfirmCreateContract_toggled(int state)
-{   LOG_CALL;
+{
+    LOG_CALL;
     qInfo() << "onConfirmCreateContract..." << state;
-    setFinalPage( not state);
+    setFinalPage(not state);
 }
 
 /*
@@ -380,35 +428,36 @@ void wpConfirmCreditor::onConfirmCreateContract_toggled(int state)
  *
  * wizNewContractData - ask basic contract data
 */
-const QString pnLabel  {qsl("label")};
-const QString pnAmount {qsl("amount")};
-const QString pnContractComment {qsl("contractComment")};
+const QString pnLabel{qsl("label")};
+const QString pnAmount{qsl("amount")};
+const QString pnContractComment{qsl("contractComment")};
 
-wpLableAndAmount::wpLableAndAmount(QWidget* p) : QWizardPage(p)
-{   LOG_CALL;
+wpLableAndAmount::wpLableAndAmount(QWidget *p) : QWizardPage(p)
+{
+    LOG_CALL;
     setTitle(qsl("Vertragsdaten"));
 
-    QLabel* l1 =new QLabel(qsl("Kennung"));
-    QLineEdit* leKennung =new QLineEdit;
+    QLabel *l1 = new QLabel(qsl("Kennung"));
+    QLineEdit *leKennung = new QLineEdit;
     leKennung->setToolTip(qsl("Über die Kennung wird der Vertrag z.B. in einem Schriftwechsel identifiziert."));
     registerField(pnLabel, leKennung);
     l1->setBuddy(leKennung);
 
-    QLabel* l2 =new QLabel(qsl("Betrag"));
-    QLineEdit* leAmount =new QLineEdit;
+    QLabel *l2 = new QLabel(qsl("Betrag"));
+    QLineEdit *leAmount = new QLineEdit;
     leAmount->setToolTip(qsl("Der Kreditbetrag muss größer als ") + dbConfig::readValue(MIN_AMOUNT).toString() + qsl("Euro sein"));
     registerField(pnAmount, leAmount);
     leAmount->setValidator(new QIntValidator(this));
     l2->setBuddy(leAmount);
 
-    QLabel* l3 =new QLabel(qsl("Anmerkung"));
-    QPlainTextEdit* eComment =new QPlainTextEdit;
+    QLabel *l3 = new QLabel(qsl("Anmerkung"));
+    QPlainTextEdit *eComment = new QPlainTextEdit;
     registerField(pnContractComment, eComment, "plainText", "textChanged");
     eComment->setToolTip(qsl("Diese Anmerkung wird mit dem Vertrag gespeichert"));
 
     contractLabel = new QLabel(qsl("Keine Daten!"));
 
-    QGridLayout* g =new QGridLayout;
+    QGridLayout *g = new QGridLayout;
     g->addWidget(contractLabel, 0, 0, 2, 2);
     g->addWidget(l1, 2, 0);
     g->addWidget(leKennung, 2, 1);
@@ -416,18 +465,19 @@ wpLableAndAmount::wpLableAndAmount(QWidget* p) : QWizardPage(p)
     g->addWidget(leAmount, 3, 1);
     g->addWidget(l3, 4, 0);
     g->addWidget(eComment, 4, 1);
-    
+
     g->setColumnStretch(0, 1);
     g->setColumnStretch(1, 4);
 
     setLayout(g);
 }
 void wpLableAndAmount::initializePage()
-{   LOG_CALL;
-    QString creditorInfo { qsl("<b>%1, %2</b><p><small>%3, %4 %5</small>")};
+{
+    LOG_CALL;
+    QString creditorInfo{qsl("<b>%1, %2</b><p><small>%3, %4 %5</small>")};
     contractLabel->setText(creditorInfo.arg(field(pnLName).toString(),
-                                 field(pnFName).toString(), field(pnStreet).toString(),
-                                 field(pnPcode).toString(), field(pnCity).toString()));
+                                            field(pnFName).toString(), field(pnStreet).toString(),
+                                            field(pnPcode).toString(), field(pnCity).toString()));
     setField(pnLabel, proposeContractLabel());
 }
 void wpLableAndAmount::cleanupPage()
@@ -446,55 +496,61 @@ void wpLableAndAmount::cleanupPage()
     setField(pnBic, QString());
 }
 bool wpLableAndAmount::validatePage()
-{   LOG_CALL;
+{
+    LOG_CALL;
     QString msg;
     setField(pnLabel, field(pnLabel.trimmed()));
     int minContractValue = dbConfig::readValue(MIN_AMOUNT).toInt();
-    const QString label =field(pnLabel).toString();
-    if( label.isEmpty())
-        msg =qsl("Die Vertragskennung darf nicht leer sein");
-    else if( not isValidNewContractLabel(label))
-        msg =qsl("Die Vertragskennung existiert bereits für einen laufenden oder beendeten Vertrag und darf nicht erneut vergeben werden");
-    else if( field(pnAmount).toInt() < minContractValue)
-        msg =qsl("Der Wert des Vertrags muss größer sein als der konfigurierte Minimalwert "
-                 "eines Vertrages von ") +dbConfig::readValue(MIN_AMOUNT).toString() +qsl(" Euro");
-    if( msg.size()) {
+    const QString label = field(pnLabel).toString();
+    if (label.isEmpty())
+        msg = qsl("Die Vertragskennung darf nicht leer sein");
+    else if (not isValidNewContractLabel(label))
+        msg = qsl("Die Vertragskennung existiert bereits für einen laufenden oder beendeten Vertrag und darf nicht erneut vergeben werden");
+    else if (field(pnAmount).toInt() < minContractValue)
+        msg = qsl("Der Wert des Vertrags muss größer sein als der konfigurierte Minimalwert "
+                  "eines Vertrages von ") +
+              dbConfig::readValue(MIN_AMOUNT).toString() + qsl(" Euro");
+    if (msg.size())
+    {
         QMessageBox::critical(this, qsl("Fehler"), msg);
         return false;
     }
     return true;
 }
 int wpLableAndAmount::nextId() const
-{   LOG_CALL;
+{
+    LOG_CALL;
     return page_contract_timeframe;
 }
 
 /*
  * wpContractTimeframe - contract date, notice period, termination date
 */
-const QString pnCDate {qsl("startD")};
-const QString pnEDate {qsl("endD")};
+const QString pnCDate{qsl("startD")};
+const QString pnEDate{qsl("endD")};
 const QString pnPeriod{qsl("noticePeriod")};
 
-wpContractTimeframe::wpContractTimeframe(QWidget* p) : QWizardPage(p)
-{   LOG_CALL;
+wpContractTimeframe::wpContractTimeframe(QWidget *p) : QWizardPage(p)
+{
+    LOG_CALL;
     setTitle(qsl("Vertragsbeginn und -Ende"));
-    setSubTitle(qsl("Für das Vertragsende kann eine Kündigungsfrist <b>oder</b> ein festes Vertragsende vereinbart werden."));
-    QDateEdit* deCDate =new QDateEdit(QDate::currentDate());
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("Für das Vertragsende kann eine Kündigungsfrist <b>oder</b> ein festes Vertragsende vereinbart werden."));
+    QDateEdit *deCDate = new QDateEdit(QDate::currentDate());
     registerField(pnCDate, deCDate);
     deCDate->setDisplayFormat(qsl("dd.MM.yyyy"));
-    QLabel* l1 =new QLabel(qsl("Vertragsdatum"));
+    QLabel *l1 = new QLabel(qsl("Vertragsdatum"));
     l1->setBuddy(deCDate);
 
-    cbNoticePeriod =new QComboBox;
+    cbNoticePeriod = new QComboBox;
     registerField(pnPeriod, cbNoticePeriod);
     cbNoticePeriod->addItem(qsl("festes Vertragsende"), QVariant(-1));
-    for (int i=3; i<12; i++)
+    for (int i = 3; i < 12; i++)
         cbNoticePeriod->addItem(QString::number(i) + qsl(" Monate"), QVariant(i));
     cbNoticePeriod->addItem(qsl("1 Jahr"), QVariant(12));
     cbNoticePeriod->addItem(qsl("1 Jahr und 1 Monat"), QVariant(13));
-    for (int i=14; i<24; i++)
-        cbNoticePeriod->addItem(qsl("1 Jahr und ") + QString::number( i-12) + qsl(" Monate"), QVariant(i));
+    for (int i = 14; i < 24; i++)
+        cbNoticePeriod->addItem(qsl("1 Jahr und ") + QString::number(i - 12) + qsl(" Monate"), QVariant(i));
     cbNoticePeriod->addItem(qsl("2 Jahre"), QVariant(24));
 
     connect(cbNoticePeriod, SIGNAL(currentIndexChanged(int)), this, SLOT(onNoticePeriod_currentIndexChanged(int)));
@@ -503,55 +559,71 @@ wpContractTimeframe::wpContractTimeframe(QWidget* p) : QWizardPage(p)
                                    "so gibt es kein festes Vertragsende. "
                                    "Um ein festes Vertragsende einzugeben wähle "
                                    "in dieser Liste \"festes Vertragsende\""));
-    QLabel* l2 =new QLabel(qsl("Kündigungsfrist"));
+    QLabel *l2 = new QLabel(qsl("Kündigungsfrist"));
     l2->setBuddy(cbNoticePeriod);
 
-    deTerminationDate =new QDateEdit;
+    deTerminationDate = new QDateEdit;
     registerField(pnEDate, deTerminationDate);
     deTerminationDate->setDisplayFormat(qsl("dd.MM.yyyy"));
-    QLabel* l3 =new QLabel(qsl("Vertragsende"));
+    QLabel *l3 = new QLabel(qsl("Vertragsende"));
     l3->setBuddy(deTerminationDate);
 
-    QGridLayout* g =new QGridLayout;
-    g->addWidget(l1, 0, 0);
-    g->addWidget(deCDate, 0, 1);
-    g->addWidget(l2, 1, 0);
-    g->addWidget(cbNoticePeriod, 1, 1);
-    g->addWidget(l3, 2, 0);
-    g->addWidget(deTerminationDate, 2, 1);
+    QGridLayout *g = new QGridLayout;
+    int row = 0;
+    g->addWidget(subTitleLabel, row, 0, 1, 2);
+
+    row++;
+    g->addWidget(l1, row, 0);
+    g->addWidget(deCDate, row, 1);
+
+    row++;
+    g->addWidget(l2, row, 0);
+    g->addWidget(cbNoticePeriod, row, 1);
+
+    row++;
+    g->addWidget(l3, row, 0);
+    g->addWidget(deTerminationDate, row, 1);
     g->setColumnStretch(0, 1);
     g->setColumnStretch(1, 4);
     setLayout(g);
 }
 void wpContractTimeframe::initializePage()
-{   LOG_CALL;
+{
+    LOG_CALL;
     setField(pnPeriod, 4);
     setField(pnEDate, EndOfTheFuckingWorld);
     deTerminationDate->setEnabled(false);
 }
 void wpContractTimeframe::onNoticePeriod_currentIndexChanged(int i)
-{   LOG_CALL;
-    if( i == 0) {
+{
+    LOG_CALL;
+    if (i == 0)
+    {
         // deTerminationDate->setDate(QDate::currentDate().addYears(5));
         setField(pnEDate, QDate::currentDate().addYears(5));
         deTerminationDate->setEnabled(true);
-    } else {
+    }
+    else
+    {
         //deTerminationDate->setDate(EndOfTheFuckingWorld);
         setField(pnEDate, EndOfTheFuckingWorld);
         deTerminationDate->setEnabled(false);
     }
 }
 bool wpContractTimeframe::validatePage()
-{   LOG_CALL;
-    QDate start =field(pnCDate).toDate();
-    QDate end   =field(pnEDate).toDate();
-    if( start > end) {
+{
+    LOG_CALL;
+    QDate start = field(pnCDate).toDate();
+    QDate end = field(pnEDate).toDate();
+    if (start > end)
+    {
         qInfo() << "Enddate is before Startdate: " << field(pnCDate).toDate() << "/" << field(pnEDate).toDate();
         return false;
     }
-    wizNew* wiz =qobject_cast<wizNew*> (wizard());
-    if( wiz) {
-        wiz->noticePeriod =cbNoticePeriod->itemData(field(pnPeriod).toInt()).toInt();
+    wizNew *wiz = qobject_cast<wizNew *>(wizard());
+    if (wiz)
+    {
+        wiz->noticePeriod = cbNoticePeriod->itemData(field(pnPeriod).toInt()).toInt();
         //        wiz->date =start;
         //        wiz->termination =end;
         return true;
@@ -560,8 +632,9 @@ bool wpContractTimeframe::validatePage()
     return true;
 }
 int wpContractTimeframe::nextId() const
-{   LOG_CALL;
-    if( nbrActiveInvestments(field(pnCDate).toDate()))
+{
+    LOG_CALL;
+    if (nbrActiveInvestments(field(pnCDate).toDate()))
         return page_interest_selection_Mode;
     else
         return page_interest_value_selection;
@@ -570,19 +643,21 @@ int wpContractTimeframe::nextId() const
 /*
  * wpInterestSelectionMode - ask: investment or interest?
 */
-const auto pnISelMode {qsl("iSelMode")};
+const auto pnISelMode{qsl("iSelMode")};
 
-wpInterestSelectionMode::wpInterestSelectionMode(QWidget* w) : QWizardPage(w)
+wpInterestSelectionMode::wpInterestSelectionMode(QWidget *w) : QWizardPage(w)
 {
     setTitle(qsl("Zinssatz"));
-    setSubTitle(qsl("Wähle, ob Du den Zins durch die Auswahl einer Geldanlage oder "
-                    "durch die Eingabe des Zinssatzes auswählen möchtest"));
-    QRadioButton* rbInvestment =new QRadioButton(qsl("Anlage auswählen"));
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("Wähle, ob Du den Zins durch die Auswahl einer Geldanlage oder "
+                               "durch die Eingabe des Zinssatzes auswählen möchtest"));
+    QRadioButton *rbInvestment = new QRadioButton(qsl("Anlage auswählen"));
     rbInvestment->setToolTip(qsl("Bestimme den Zinssatz über die Auswahl einer Geldanlage"));
-    QRadioButton* rbInterest   =new QRadioButton(qsl("Zinssatz auswählen"));
+    QRadioButton *rbInterest = new QRadioButton(qsl("Zinssatz auswählen"));
     rbInterest->setToolTip(qsl("Bestimme den Zinssatz direkt"));
     registerField(pnISelMode, rbInvestment);
-    QVBoxLayout* vl =new QVBoxLayout();
+    QVBoxLayout *vl = new QVBoxLayout();
+    vl->addWidget(subTitleLabel);
     vl->addWidget(rbInvestment);
     vl->addWidget(rbInterest);
     setLayout(vl);
@@ -593,7 +668,7 @@ void wpInterestSelectionMode::initializePage()
 }
 int wpInterestSelectionMode::nextId() const
 {
-    if(field(pnISelMode).toBool())
+    if (field(pnISelMode).toBool())
         return page_interest_from_investment;
     else
         return page_interest_value_selection;
@@ -604,12 +679,12 @@ int wpInterestSelectionMode::nextId() const
 */
 const QString pnI_CheckBoxIndex{qsl("iByInvestment")};
 
-wpInterestFromInvestment::wpInterestFromInvestment(QWidget* w) : QWizardPage(w)
+wpInterestFromInvestment::wpInterestFromInvestment(QWidget *w) : QWizardPage(w)
 {
     setTitle(qsl("Wähle die gewünschte Geldanlage aus der Liste aus"));
-    cbInvestments =new QComboBox();
-    lblInvestmentInfo =new QLabel();
-    QVBoxLayout* l =new QVBoxLayout();
+    cbInvestments = new QComboBox();
+    lblInvestmentInfo = new QLabel();
+    QVBoxLayout *l = new QVBoxLayout();
     l->addWidget(cbInvestments);
     l->addWidget(lblInvestmentInfo);
     setLayout(l);
@@ -623,36 +698,39 @@ wpInterestFromInvestment::wpInterestFromInvestment(QWidget* w) : QWizardPage(w)
 }
 void wpInterestFromInvestment::initializePage()
 {
-    QVector<QPair<qlonglong, QString>> investments =activeInvestments(field(pnCDate).toDate());
+    QVector<QPair<qlonglong, QString>> investments = activeInvestments(field(pnCDate).toDate());
     cbInvestments->clear();
-    for( const auto &invest : qAsConst(investments)) {
+    for (const auto &invest : qAsConst(investments))
+    {
         cbInvestments->addItem(invest.second, invest.first);
     }
     registerField(pnI_CheckBoxIndex, cbInvestments);
 }
-void wpInterestFromInvestment::onInvestments_currentIndexChanged(int ) {
-    qlonglong rowId =cbInvestments->currentData().toLongLong();
-    double amount =field(pnAmount).toDouble();
-    QString html =investmentInfoForNewContract(rowId, amount);
+void wpInterestFromInvestment::onInvestments_currentIndexChanged(int)
+{
+    qlonglong rowId = cbInvestments->currentData().toLongLong();
+    double amount = field(pnAmount).toDouble();
+    QString html = investmentInfoForNewContract(rowId, amount);
     lblInvestmentInfo->setText(html);
 }
 bool wpInterestFromInvestment::validatePage()
 {
     rowid_investment = cbInvestments->currentData().toLongLong();
-    wizNew* wiz =qobject_cast<wizNew*>(wizard());
-    wiz->interest =interestOfInvestmentByRowId(rowid_investment);
-    wiz->investmentId =rowid_investment;
-    if( wiz->interest == 0){
+    wizNew *wiz = qobject_cast<wizNew *>(wizard());
+    wiz->interest = interestOfInvestmentByRowId(rowid_investment);
+    wiz->investmentId = rowid_investment;
+    if (wiz->interest == 0)
+    {
         // without interest -> interest payout mode "zero"
-        wiz->iPaymentMode =interestModel::zero;
+        wiz->iPaymentMode = interestModel::zero;
     }
 
     return true;
 }
 int wpInterestFromInvestment::nextId() const
 {
-    wizNew* wiz =qobject_cast<wizNew*>(wizard());
-    if( wiz->interest == 0)
+    wizNew *wiz = qobject_cast<wizNew *>(wizard());
+    if (wiz->interest == 0)
         return page_confirm_contract;
     else
         return page_interest_payment_mode;
@@ -661,23 +739,25 @@ int wpInterestFromInvestment::nextId() const
 /*
  * wpNewContractInterest - interest value from Investment or comboBox, interest mode
 */
-const QString pnInterestIndex {qsl("iIndex")};
+const QString pnInterestIndex{qsl("iIndex")};
 
-wpInterestSelection::wpInterestSelection(QWidget* w) : QWizardPage(w)
+wpInterestSelection::wpInterestSelection(QWidget *w) : QWizardPage(w)
 {
     setTitle(qsl("Zinssatz"));
-    setSubTitle(qsl("Wähle den Zinssatz aus"));
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("Wähle den Zinssatz aus"));
 
-    QLabel* lZ =new QLabel(qsl("Zinssatz"));
-    QComboBox* cbInterest =new QComboBox;
+    QLabel *lZ = new QLabel(qsl("Zinssatz"));
+    QComboBox *cbInterest = new QComboBox;
     lZ->setBuddy(cbInterest);
     cbInterest->addItem(qsl("Zinslos"), QVariant(0));
-    const int max_interest =dbConfig::readValue(MAX_INTEREST).toInt();
-    for( int i =1; i <= max_interest; i++)
-        cbInterest->addItem(QString::number(double(i)/100., 'f', 2), QVariant(i));
+    const int max_interest = dbConfig::readValue(MAX_INTEREST).toInt();
+    for (int i = 1; i <= max_interest; i++)
+        cbInterest->addItem(QString::number(double(i) / 100., 'f', 2), QVariant(i));
     cbInterest->setCurrentIndex(qMin(90, cbInterest->count()));
     registerField(pnInterestIndex, cbInterest);
-    QHBoxLayout* hbl =new QHBoxLayout();
+    QHBoxLayout *hbl = new QHBoxLayout();
+    hbl->addWidget(subTitleLabel);
     hbl->addWidget(lZ);
     hbl->addWidget(cbInterest);
     setLayout(hbl);
@@ -685,18 +765,18 @@ wpInterestSelection::wpInterestSelection(QWidget* w) : QWizardPage(w)
 bool wpInterestSelection::validatePage()
 {
     // without interest -> interest payout mode "payout"
-    wizNew* wiz =qobject_cast<wizNew*>(wizard());
-    if( field(pnInterestIndex) == 0)
-        wiz->iPaymentMode =interestModel::zero;
+    wizNew *wiz = qobject_cast<wizNew *>(wizard());
+    if (field(pnInterestIndex) == 0)
+        wiz->iPaymentMode = interestModel::zero;
     else
-        wiz->iPaymentMode =interestModel::payout; // default for the next wiz page
+        wiz->iPaymentMode = interestModel::payout; // default for the next wiz page
     return true;
 }
 int wpInterestSelection::nextId() const
 {
-    wizNew* wiz =qobject_cast<wizNew*>(wizard());
-    wiz->interest =field(pnInterestIndex).toInt();
-    if( wiz->interest == 0)
+    wizNew *wiz = qobject_cast<wizNew *>(wizard());
+    wiz->interest = field(pnInterestIndex).toInt();
+    if (wiz->interest == 0)
         return page_confirm_contract;
     else
         return page_interest_payment_mode;
@@ -705,14 +785,15 @@ int wpInterestSelection::nextId() const
 /*
  * wpInterestMode - kein Zins? thesaurierend? Auszahlend? Fix?
 */
-const QString pnIMode {qsl("imode")};
-const QString pnIPaymentDelayed {qsl("ipnd")};
-wpInterestPayoutMode::wpInterestPayoutMode(QWidget* p) : QWizardPage(p)
+const QString pnIMode{qsl("imode")};
+const QString pnIPaymentDelayed{qsl("ipnd")};
+wpInterestPayoutMode::wpInterestPayoutMode(QWidget *p) : QWizardPage(p)
 {
     setTitle(qsl("Zinsmodus"));
-    setSubTitle(qsl("Wähle den Zinsmodus für diesen Vertrag"));
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("Wähle den Zinsmodus für diesen Vertrag"));
 
-    cbImode =new QComboBox();
+    cbImode = new QComboBox();
     cbImode->addItem(qsl("Zinsen werden ausgezahlt"));
     cbImode->setItemData(0, toInt(interestModel::payout));
     cbImode->addItem(qsl("Zinsen werden angespart und verzinst"));
@@ -725,14 +806,15 @@ wpInterestPayoutMode::wpInterestPayoutMode(QWidget* p) : QWizardPage(p)
     cbImode->setCurrentIndex(1);
     registerField(pnIMode, cbImode);
 
-    QRadioButton* rbSync =new QRadioButton(qsl("Die Zinszahlung beginnt mit dem Geldeingang"));
+    QRadioButton *rbSync = new QRadioButton(qsl("Die Zinszahlung beginnt mit dem Geldeingang"));
     rbSync->setToolTip(qsl("Meist beginnt die Zinanrechnung mit dem Geldeingang auf dem Konto des Projektes."));
-    QRadioButton* rbDelayed =new QRadioButton(qsl("Die Zinszahlung beginnt später"));
+    QRadioButton *rbDelayed = new QRadioButton(qsl("Die Zinszahlung beginnt später"));
     rbDelayed->setToolTip(qsl("Es kann auch vereinbart werden, dass die Zinsanrechnung verzögert - z.B. mit dem Baubeginn - beginnt."));
     rbSync->setChecked(true);
     registerField(pnIPaymentDelayed, rbDelayed);
 
-    QVBoxLayout* vbl =new QVBoxLayout();
+    QVBoxLayout *vbl = new QVBoxLayout();
+    vbl->addWidget(subTitleLabel);
     vbl->addWidget(cbImode);
     vbl->addWidget(rbSync);
     vbl->addWidget(rbDelayed);
@@ -740,8 +822,8 @@ wpInterestPayoutMode::wpInterestPayoutMode(QWidget* p) : QWizardPage(p)
 }
 bool wpInterestPayoutMode::validatePage()
 {
-    wizNew* wiz =qobject_cast<wizNew*>(wizard());
-    wiz->iPaymentMode =fromInt(cbImode->itemData(field(pnIMode).toInt()).toInt());
+    wizNew *wiz = qobject_cast<wizNew *>(wizard());
+    wiz->iPaymentMode = fromInt(cbImode->itemData(field(pnIMode).toInt()).toInt());
     return true;
 }
 int wpInterestPayoutMode::nextId() const
@@ -752,64 +834,58 @@ int wpInterestPayoutMode::nextId() const
 /*
 * wizConfirmContract  -confirm the contract data before contract creation
 */
-const QString pnConfirmContract {qsl("confirmContract")};
+const QString pnConfirmContract{qsl("confirmContract")};
 
-wpConfirmContract::wpConfirmContract(QWidget* p) : QWizardPage(p)
-{   LOG_CALL;
+wpConfirmContract::wpConfirmContract(QWidget *p) : QWizardPage(p)
+{
+    LOG_CALL;
     setTitle(qsl("Bestätige die Vertragsdaten"));
-    QCheckBox* cbConfirm =new QCheckBox(qsl("Die Angaben sind korrekt!"));
+    QCheckBox *cbConfirm = new QCheckBox(qsl("Die Angaben sind korrekt!"));
     cbConfirm->setCheckState(Qt::CheckState::Unchecked);
-    registerField(pnConfirmContract +qsl("*"), cbConfirm);
-    QVBoxLayout* bl =new QVBoxLayout;
-    cbContractLabel = new QLabel("Keine Daten!");
-    bl->addWidget(cbContractLabel);
+    registerField(pnConfirmContract + qsl("*"), cbConfirm);
+    QVBoxLayout *bl = new QVBoxLayout;
+    bl->addWidget(subTitleLabel);
     bl->addWidget(cbConfirm);
     setLayout(bl);
     setCommitPage(true);
 }
 void wpConfirmContract::initializePage()
-{   LOG_CALL;
+{
+    LOG_CALL;
 
-    QString summary {qsl("Vertrag <b>%3</b> von <b>%1 %2</b> <p><table>"
-                         //"<tr><td>Kennung: </td><td><b>%3</b><p></td></tr>"
-                         "<tr><td>Betrag: </td><td><b>%4</b></td></tr>"
-                         "<tr><td>Zinssatz: </td><td><b>%5 %</b></td></tr>"
-                         "<tr><td>Zinsanrechnung: </td><td><b>%6<p></b></td></tr>"
-                         "<tr><td>Abschlußdatum: </td><td><b>%7</b></td></tr>"
-                         "<tr><td>Vertragsende: </td><td><b>%8</b></td></tr>"
-                         "<tr><td>Verzinsungsbeginn: </td><td>%9</b></td></tr>"
-                         "</table>")};
+    QString summary{qsl("Vertrag <b>%3</b> von <b>%1 %2</b> <p><table>"
+                        //"<tr><td>Kennung: </td><td><b>%3</b><p></td></tr>"
+                        "<tr><td>Betrag: </td><td><b>%4</b></td></tr>"
+                        "<tr><td>Zinssatz: </td><td><b>%5 %</b></td></tr>"
+                        "<tr><td>Zinsanrechnung: </td><td><b>%6<p></b></td></tr>"
+                        "<tr><td>Abschlußdatum: </td><td><b>%7</b></td></tr>"
+                        "<tr><td>Vertragsende: </td><td><b>%8</b></td></tr>"
+                        "<tr><td>Verzinsungsbeginn: </td><td>%9</b></td></tr>"
+                        "</table>")};
     QLocale l;
 
-
-    wizNew* wiz =qobject_cast<wizNew*> (wizard());
-    if( wiz)
+    wizNew *wiz = qobject_cast<wizNew *>(wizard());
+    if (wiz)
     {
         interestModel iMode{wiz->iPaymentMode};
-        QString interestMode =toString(iMode);
-        cbContractLabel->setText(
-                    summary.arg(field(pnFName).toString(), field(pnLName).toString()
-                                , field(pnLabel).toString()
-                                , l.toCurrencyString(field(pnAmount).toDouble())
-                                , QString::number(wiz->interest/100., 'f', 2)
-                                , interestMode
-                                , field(pnCDate).toDate().toString(qsl("dd.MM.yyyy"))
-                                , (wiz->noticePeriod == -1) ?
-                                    wiz->field(pnEDate).toDate().toString(qsl("dd.MM.yyyy")) :
-                                    QString::number(wiz->noticePeriod) +qsl(" Monate nach Kündigung")
-                                , field(pnIPaymentDelayed).toBool() ? qsl("Zinszahlung nicht ab Geldeingang") : qsl("Verzinsung ab Geldeingang")));
-    } else Q_ASSERT(false);
+        QString interestMode = toString(iMode);
+        subTitleLabel->setText(
+            summary.arg(field(pnFName).toString(), field(pnLName).toString(), field(pnLabel).toString(), l.toCurrencyString(field(pnAmount).toDouble()), QString::number(wiz->interest / 100., 'f', 2), interestMode, field(pnCDate).toDate().toString(qsl("dd.MM.yyyy")), (wiz->noticePeriod == -1) ? wiz->field(pnEDate).toDate().toString(qsl("dd.MM.yyyy")) : QString::number(wiz->noticePeriod) + qsl(" Monate nach Kündigung"), field(pnIPaymentDelayed).toBool() ? qsl("Zinszahlung nicht ab Geldeingang") : qsl("Verzinsung ab Geldeingang")));
+    }
+    else
+        Q_ASSERT(false);
 }
 
 /*
 * wizNew - the wizard containing the pages to create a cerditor and a contract
 */
 wizNew::wizNew(QWidget *p) : QWizard(p)
-{   LOG_CALL;
+{
+    LOG_CALL;
     // setOption(QWizard::IndependentPages);
     setPage(page_new_or_existing, new wpNewOrExisting(this));
     setPage(page_address, new wpNewCreditorAddress(this));
-    setPage(page_email,   new wpEmail(this));
+    setPage(page_email, new wpEmail(this));
     setPage(page_bankaccount, new wpBankAccount(this));
     setPage(page_confirm_creditor, new wpConfirmCreditor(this));
     setPage(page_label_and_amount, new wpLableAndAmount(this));
@@ -819,5 +895,7 @@ wizNew::wizNew(QWidget *p) : QWizard(p)
     setPage(page_interest_payment_mode, new wpInterestPayoutMode(this));
     setPage(page_contract_timeframe, new wpContractTimeframe(this));
     setPage(page_confirm_contract, new wpConfirmContract(this));
-    QFont f = font(); f.setPointSize(10); setFont(f);
+    QFont f = font();
+    f.setPointSize(10);
+    setFont(f);
 }

--- a/DKV2/wiznew.cpp
+++ b/DKV2/wiznew.cpp
@@ -303,8 +303,9 @@ wpConfirmCreditor::wpConfirmCreditor(QWidget* p) : QWizardPage(p)
     cbCreateContract->setToolTip(qsl("Selektiere dieses Feld, um gleich einen neuen Vertrag anzulegen"));
     registerField(pnCreateContract, cbCreateContract);
     cbCreateContract->setChecked(true);
-
+    cbCreditorLabel = new QLabel(qsl("Keine Daten"));
     QVBoxLayout* l =new QVBoxLayout;
+    l->addWidget(cbCreditorLabel); //
     l->addWidget(cbConfirmCreditor);
     l->addWidget(cbCreateContract);
     setLayout(l);
@@ -313,12 +314,12 @@ wpConfirmCreditor::wpConfirmCreditor(QWidget* p) : QWizardPage(p)
 }
 void wpConfirmCreditor::initializePage()
 {   LOG_CALL;
-    QString creditorSummary {qsl("<table><tr><td>Name:</td><td><b>%1 %2</b><br></td></tr>"
-                                 "<tr><td>Straße:</td><td>%3</td></tr>"
-                                 "<tr><td>Plz/Ort:</td><td>%4</td></tr>"
-                                 "<tr><td>E-Mail:</td><td>%5<br></td></tr>"
-                                 "<tr><td>Kommentar:</td><td><small>%6<small></td></tr>"
-                                 "<tr><td>Bankdaten:</td><td><table><tr><td>IBAN:</td><td>%7</td></tr><tr><td>BIC:</td><td>%8<td></tr></table></td></tr></table>")};
+    QString creditorSummary{qsl("<table><tr><td>Name:</td><td><b>%1 %2</b><br></td></tr>"
+                                "<tr><td>Straße:</td><td>%3</td></tr>"
+                                "<tr><td>Plz/Ort:</td><td>%4</td></tr>"
+                                "<tr><td>E-Mail:</td><td>%5<br></td></tr>"
+                                "<tr><td>Kommentar:</td><td><small>%6<small></td></tr>"
+                                "<tr><td>Bankdaten:</td><td><table><tr><td>IBAN:</td><td>%7</td></tr><tr><td>BIC:</td><td>%8<td></tr></table></td></tr></table>")};
     QString firstn =field(pnFName).toString().isEmpty() ? qsl("(kein Vorname)")  : field(pnFName).toString();
     QString lastn  =field(pnLName).toString().isEmpty()  ? qsl("(kein Nachname)") : field(pnLName).toString();
     QString street =field(pnStreet).toString().isEmpty()    ? qsl("(keine Strasse)") : field(pnStreet).toString();
@@ -334,7 +335,7 @@ void wpConfirmCreditor::initializePage()
     QString iban   =field(pnIban).toString().isEmpty()      ? qsl("(keine IBAN)")     : field(pnIban).toString();
     QString bic    =field(pnBic).toString().isEmpty()       ? qsl("(keine BIC)")      : field(pnBic).toString();
 
-    setSubTitle(creditorSummary.arg(firstn, lastn, street, xxx,
+    cbCreditorLabel->setText(creditorSummary.arg(firstn, lastn, street, xxx,
                                     email, comment, iban, bic));
     wizNew* wiz =qobject_cast<wizNew*> (wizard());
     if( wiz->selectCreateContract)
@@ -405,13 +406,17 @@ wpLableAndAmount::wpLableAndAmount(QWidget* p) : QWizardPage(p)
     registerField(pnContractComment, eComment, "plainText", "textChanged");
     eComment->setToolTip(qsl("Diese Anmerkung wird mit dem Vertrag gespeichert"));
 
+    contractLabel = new QLabel(qsl("Keine Daten!"));
+
     QGridLayout* g =new QGridLayout;
-    g->addWidget(l1, 0, 0);
-    g->addWidget(leKennung, 0, 1);
-    g->addWidget(l2, 1, 0);
-    g->addWidget(leAmount, 1, 1);
-    g->addWidget(l3, 2, 0);
-    g->addWidget(eComment, 2, 1);
+    g->addWidget(contractLabel, 0, 0, 2, 2);
+    g->addWidget(l1, 2, 0);
+    g->addWidget(leKennung, 2, 1);
+    g->addWidget(l2, 3, 0);
+    g->addWidget(leAmount, 3, 1);
+    g->addWidget(l3, 4, 0);
+    g->addWidget(eComment, 4, 1);
+    
     g->setColumnStretch(0, 1);
     g->setColumnStretch(1, 4);
 
@@ -419,8 +424,8 @@ wpLableAndAmount::wpLableAndAmount(QWidget* p) : QWizardPage(p)
 }
 void wpLableAndAmount::initializePage()
 {   LOG_CALL;
-    QString creditorInfo { qsl("%1, %2<p><small>%3 %4 %5</small>")};
-    setSubTitle(creditorInfo.arg(field(pnLName).toString(),
+    QString creditorInfo { qsl("<b>%1, %2</b><p><small>%3, %4 %5</small>")};
+    contractLabel->setText(creditorInfo.arg(field(pnLName).toString(),
                                  field(pnFName).toString(), field(pnStreet).toString(),
                                  field(pnPcode).toString(), field(pnCity).toString()));
     setField(pnLabel, proposeContractLabel());
@@ -756,6 +761,8 @@ wpConfirmContract::wpConfirmContract(QWidget* p) : QWizardPage(p)
     cbConfirm->setCheckState(Qt::CheckState::Unchecked);
     registerField(pnConfirmContract +qsl("*"), cbConfirm);
     QVBoxLayout* bl =new QVBoxLayout;
+    cbContractLabel = new QLabel("Keine Daten!");
+    bl->addWidget(cbContractLabel);
     bl->addWidget(cbConfirm);
     setLayout(bl);
     setCommitPage(true);
@@ -780,7 +787,8 @@ void wpConfirmContract::initializePage()
     {
         interestModel iMode{wiz->iPaymentMode};
         QString interestMode =toString(iMode);
-        setSubTitle(summary.arg(field(pnFName).toString(), field(pnLName).toString()
+        cbContractLabel->setText(
+                    summary.arg(field(pnFName).toString(), field(pnLName).toString()
                                 , field(pnLabel).toString()
                                 , l.toCurrencyString(field(pnAmount).toDouble())
                                 , QString::number(wiz->interest/100., 'f', 2)

--- a/DKV2/wiznew.h
+++ b/DKV2/wiznew.h
@@ -46,6 +46,7 @@ private:
     QRadioButton* rbNew;
     QRadioButton* rbExisting;
     QComboBox*    cbCreditors;
+    QLabel*       subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 /*
@@ -65,6 +66,7 @@ struct wpNewCreditorAddress : public QWizardPage{
     int nextId() const    override;
 private:
     Q_OBJECT;
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 extern const QString pnEMail;
@@ -77,6 +79,7 @@ struct wpEmail : public QWizardPage {
     int nextId() const    override;
 private:
     Q_OBJECT;
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 extern const QString pnIban;
@@ -89,6 +92,7 @@ struct wpBankAccount : public QWizardPage{
     int nextId() const    override;
 private:
     Q_OBJECT;
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 extern const QString pnConfirmCreditor;
@@ -104,7 +108,7 @@ public slots:
     void onConfirmCreateContract_toggled(int state);
 private:
     QCheckBox*  cbCreateContract =nullptr;
-    QLabel*     cbCreditorLabel = nullptr;
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 /********************************
@@ -127,6 +131,7 @@ struct wpLableAndAmount : public QWizardPage{
 private:
     Q_OBJECT;
     QLabel* contractLabel = nullptr;
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 /*
@@ -152,6 +157,7 @@ private:
     bool init =true;
     QDateEdit* deTerminationDate; // to enable / disable we need the pointer to the cBox
     QComboBox* cbNoticePeriod;    // to access the itemData
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 /*
@@ -164,6 +170,7 @@ struct wpInterestSelectionMode : public QWizardPage {
     int nextId() const override;
 private:
     Q_OBJECT;
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 /*
@@ -182,6 +189,7 @@ private:
     QComboBox* cbInvestments =nullptr; // to read itemData on validation
     QLabel* lblInvestmentInfo =nullptr;
     qlonglong rowid_investment =-1;
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 /*
@@ -193,6 +201,7 @@ struct wpInterestSelection : public QWizardPage {
     int nextId() const    override;
 private:
     Q_OBJECT;
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 /*
@@ -206,6 +215,7 @@ struct wpInterestPayoutMode : public QWizardPage {
 private:
     Q_OBJECT;
     QComboBox* cbImode =nullptr;
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 /*
@@ -220,7 +230,7 @@ public:
     wpConfirmContract(QWidget*);
     void initializePage() override;
 private:
-    QLabel* cbContractLabel = nullptr;
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 /*

--- a/DKV2/wiznew.h
+++ b/DKV2/wiznew.h
@@ -103,7 +103,8 @@ public:
 public slots:
     void onConfirmCreateContract_toggled(int state);
 private:
-    QCheckBox* cbCreateContract =nullptr;
+    QCheckBox*  cbCreateContract =nullptr;
+    QLabel*     cbCreditorLabel = nullptr;
 };
 
 /********************************
@@ -125,6 +126,7 @@ struct wpLableAndAmount : public QWizardPage{
     int nextId() const    override;
 private:
     Q_OBJECT;
+    QLabel* contractLabel = nullptr;
 };
 
 /*
@@ -217,6 +219,8 @@ class wpConfirmContract : public QWizardPage
 public:
     wpConfirmContract(QWidget*);
     void initializePage() override;
+private:
+    QLabel* cbContractLabel = nullptr;
 };
 
 /*

--- a/DKV2/wiznewdatabase.cpp
+++ b/DKV2/wiznewdatabase.cpp
@@ -18,12 +18,14 @@
  * general page to select a file name
  * NOT used for newDB
 */
-wpFileSelection_IntroPage::wpFileSelection_IntroPage(QWidget* p) : QWizardPage(p) {
-    QLineEdit* le = new QLineEdit;
+wpFileSelection_IntroPage::wpFileSelection_IntroPage(QWidget *p) : QWizardPage(p)
+{
+    QLineEdit *le = new QLineEdit;
     le->setToolTip(qsl("Hier kannst du einen vollständigen Pfad zu einer Datei angeben"));
     registerField(qsl("selectedFile"), le);
-    QLabel* l =new QLabel(qsl("Klicke auf 'durchsuchen' um eine Dateiauswahlfenster zu öffnen."));
-    QVBoxLayout* layout =new QVBoxLayout;
+    QLabel *l = new QLabel(qsl("Klicke auf 'durchsuchen' um ein Dateiauswahlfenster zu öffnen."));
+    QVBoxLayout *layout = new QVBoxLayout;
+    layout->addWidget(subTitleLabel);
     layout->addWidget(l);
     layout->addWidget(le);
     setLayout(layout);
@@ -31,31 +33,37 @@ wpFileSelection_IntroPage::wpFileSelection_IntroPage(QWidget* p) : QWizardPage(p
 
 void wpFileSelection_IntroPage::initializePage()
 {
-    wizFileSelectionWiz* wiz = qobject_cast<wizFileSelectionWiz*>(wizard());
-    if( wiz) {
+    wizFileSelectionWiz *wiz = qobject_cast<wizFileSelectionWiz *>(wizard());
+    if (wiz)
+    {
         setTitle(wiz->title);
-        setSubTitle(wiz->subtitle);
+        subTitleLabel->setText(wiz->subtitle);
     }
 }
 
-void wpFileSelection_IntroPage::browseButtonClicked() {
-    wizFileSelectionWiz* wiz = qobject_cast<wizFileSelectionWiz*>(wizard());
+void wpFileSelection_IntroPage::browseButtonClicked()
+{
+    wizFileSelectionWiz *wiz = qobject_cast<wizFileSelectionWiz *>(wizard());
 
-    QString selectedFile =( wiz->existingFile) ? QFileDialog::getOpenFileName(nullptr, wiz->bffTitle, wiz->openInFolder, wiz->fileTypeDescription, nullptr)
-            : QFileDialog::getSaveFileName(nullptr, wiz->bffTitle, wiz->openInFolder, wiz->fileTypeDescription, nullptr);
-    if(selectedFile.isEmpty())
+    QString selectedFile = (wiz->existingFile) ? QFileDialog::getOpenFileName(nullptr, wiz->bffTitle, wiz->openInFolder, wiz->fileTypeDescription, nullptr)
+                                               : QFileDialog::getSaveFileName(nullptr, wiz->bffTitle, wiz->openInFolder, wiz->fileTypeDescription, nullptr);
+    if (selectedFile.isEmpty())
         return;
     setField(qsl("selectedFile"), selectedFile);
 }
 
-bool wpFileSelection_IntroPage::validatePage() {
-    wizFileSelectionWiz* wiz = qobject_cast<wizFileSelectionWiz*>(wizard());
-    QString file =field(qsl("selectedFile")).toString();
+bool wpFileSelection_IntroPage::validatePage()
+{
+    wizFileSelectionWiz *wiz = qobject_cast<wizFileSelectionWiz *>(wizard());
+    QString file = field(qsl("selectedFile")).toString();
     QFileInfo fi(file);
-    if( fi.suffix() == qsl("")) file +=qsl(".dkdb");
-    if( fi.path() == qsl(".")) file =wiz->openInFolder + qsl("/") +file;
+    if (fi.suffix() == qsl(""))
+        file += qsl(".dkdb");
+    if (fi.path() == qsl("."))
+        file = wiz->openInFolder + qsl("/") + file;
     setField(qsl("selectedFile"), file);
-    if( wiz->existingFile) {
+    if (wiz->existingFile)
+    {
 
         return QFile::exists(file);
     }
@@ -63,16 +71,20 @@ bool wpFileSelection_IntroPage::validatePage() {
         return not field(qsl("selectedFile")).toString().isEmpty();
 }
 
-void wpFileSelection_IntroPage::setVisible(bool v) {
+void wpFileSelection_IntroPage::setVisible(bool v)
+{
     QWizardPage::setVisible(v);
     wizard()->setOption(QWizard::HaveCustomButton1, v);
-    if( v) {
+    if (v)
+    {
         wizard()->setButtonText(QWizard::CustomButton1, qsl("durch&suchen"));
         connect(wizard(), &QWizard::customButtonClicked,
                 this, &wpFileSelection_IntroPage::browseButtonClicked);
-    } else {
+    }
+    else
+    {
         disconnect(wizard(), &QWizard::customButtonClicked,
-                this, &wpFileSelection_IntroPage::browseButtonClicked);
+                   this, &wpFileSelection_IntroPage::browseButtonClicked);
     }
 }
 
@@ -80,61 +92,78 @@ void wpFileSelection_IntroPage::setVisible(bool v) {
  * minimal wizard to select a file
  * for copyDb or openDb
 */
-wizFileSelectionWiz::wizFileSelectionWiz(QWidget* p) : QWizard(p) {
-    QFont f = font(); f.setPointSize(10); setFont(f);
+wizFileSelectionWiz::wizFileSelectionWiz(QWidget *p) : QWizard(p)
+{
+    QFont f = font();
+    f.setPointSize(10);
+    setFont(f);
     addPage(new wpFileSelection_IntroPage);
 }
 
 /*
  * page to select a file name used for newDB
 */
-wpFileSelectionNewDb_IntroPage::wpFileSelectionNewDb_IntroPage(QWidget* p) : QWizardPage(p) {
+wpFileSelectionNewDb_IntroPage::wpFileSelectionNewDb_IntroPage(QWidget *p) : QWizardPage(p)
+{
+    subTitleLabel->setWordWrap(true);
+    QVBoxLayout *layout = new QVBoxLayout;
+    layout->addWidget(subTitleLabel);
+    setLayout(layout);
 }
 
 void wpFileSelectionNewDb_IntroPage::initializePage()
 {
     setTitle(qsl("DB Konfiguration"));
-    setSubTitle(qsl("Mit den folgenden Dialogen kannst Du die Datenbank "
-    "für Euer Projekt konfigurieren"));
+    subTitleLabel->setText(qsl("Mit den folgenden Dialogen kannst Du die Datenbank "
+                    "für Euer Projekt konfigurieren"));
 }
 
 /*
  * page to enter GmbH address data
 */
-wpProjectAddress_Page::wpProjectAddress_Page(QWidget* p) : QWizardPage(p)
+wpProjectAddress_Page::wpProjectAddress_Page(QWidget *p) : QWizardPage(p)
 {
     setTitle(qsl("Adresse der Projekt GmbH"));
     //QLabel* lDisclaimer = new QLabel();
-    setSubTitle(qsl("*<small>Diese Daten werden für Briefdruck benötigt und können auch später eingegeben und geändert werden.</small>"));
-    QLineEdit* leAddress1 = new QLineEdit;
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("*<small>Diese Daten werden für Briefdruck benötigt und können auch später eingegeben und geändert werden.</small>"));
+    QLineEdit *leAddress1 = new QLineEdit;
     registerField(dbConfig::paramName(GMBH_ADDRESS1), leAddress1);
     leAddress1->setToolTip(qsl("Gib hier die erste Adresszeile der GmbH ein"));
-    QLineEdit* leAddress2 = new QLineEdit;
+    QLineEdit *leAddress2 = new QLineEdit;
     registerField(dbConfig::paramName(GMBH_ADDRESS2), leAddress2);
     leAddress2->setToolTip(qsl("Gib hier die zweite Adresszeile der GmbH ein"));
-    QLineEdit* leStrasse =  new QLineEdit;
+    QLineEdit *leStrasse = new QLineEdit;
     registerField(dbConfig::paramName(GMBH_STREET), leStrasse);
     leStrasse->setToolTip(qsl("Gib hier die Straße der GmbH ein."));
-    QLineEdit* lePlz =      new QLineEdit;
+    QLineEdit *lePlz = new QLineEdit;
     registerField(dbConfig::paramName(GMBH_PLZ), lePlz);
     lePlz->setToolTip(qsl("Gib hier die Postleitzahl der GmbH ein"));
-    QLineEdit* leStadt =    new QLineEdit;
+    QLineEdit *leStadt = new QLineEdit;
     registerField(dbConfig::paramName(GMBH_CITY), leStadt);
     leStadt->setToolTip(qsl("Gib hier die Stadt ein, in der die GmbH ist."));
-    QLineEdit* leEmail =    new QLineEdit;
+    QLineEdit *leEmail = new QLineEdit;
     registerField(dbConfig::paramName(GMBH_EMAIL), leEmail);
     leEmail->setToolTip(qsl("Gib hier die E-Mailadresse an, unter der die GmbH erreichbar ist."));
-    QLineEdit* leUrl   =    new QLineEdit;
+    QLineEdit *leUrl = new QLineEdit;
     registerField(dbConfig::paramName(GMBH_URL), leUrl);
 
-    QGridLayout* grid      =new QGridLayout;
-    grid->addWidget(leAddress1, 0, 0, 1, 3);
-    grid->addWidget(leAddress2, 1, 0, 1, 3);
-    grid->addWidget(leStrasse,  2, 0, 1, 3);
-    grid->addWidget(lePlz,      3, 0);
-    grid->addWidget(leStadt,    3, 1, 1, 2);
-    grid->addWidget(leEmail,    4, 0, 1, 3);
-    grid->addWidget(leUrl,      5, 0, 1, 3);
+    QGridLayout *grid = new QGridLayout;
+    int row = 0;
+    grid->addWidget(subTitleLabel, row, 0, 1, 3);
+    row++;
+    grid->addWidget(leAddress1, row, 0, 1, 3);
+    row++;
+    grid->addWidget(leAddress2, row, 0, 1, 3);
+    row++;
+    grid->addWidget(leStrasse, row, 0, 1, 3);
+    row++;
+    grid->addWidget(lePlz, row, 0);
+    grid->addWidget(leStadt, row, 1, 1, 2);
+    row++;
+    grid->addWidget(leEmail, row, 0, 1, 3);
+    row++;
+    grid->addWidget(leUrl, row, 0, 1, 3);
     grid->setColumnStretch(0, 1);
     grid->setColumnStretch(1, 4);
     // grid->setHorizontalSpacing(0);
@@ -143,47 +172,55 @@ wpProjectAddress_Page::wpProjectAddress_Page(QWidget* p) : QWizardPage(p)
 
 void wpProjectAddress_Page::initializePage()
 {
-    setField(dbConfig::paramName(GMBH_ADDRESS1),  dbConfig::readValue(GMBH_ADDRESS1));
-    setField(dbConfig::paramName(GMBH_ADDRESS2),  dbConfig::readValue(GMBH_ADDRESS2));
-    setField(dbConfig::paramName(GMBH_STREET),    dbConfig::readValue(GMBH_STREET));
-    setField(dbConfig::paramName(GMBH_PLZ),       dbConfig::readValue(GMBH_PLZ));
-    setField(dbConfig::paramName(GMBH_CITY),      dbConfig::readValue(GMBH_CITY));
-    setField(dbConfig::paramName(GMBH_EMAIL),     dbConfig::readValue(GMBH_EMAIL));
-    setField(dbConfig::paramName(GMBH_URL),       dbConfig::readValue(GMBH_URL));
+    setField(dbConfig::paramName(GMBH_ADDRESS1), dbConfig::readValue(GMBH_ADDRESS1));
+    setField(dbConfig::paramName(GMBH_ADDRESS2), dbConfig::readValue(GMBH_ADDRESS2));
+    setField(dbConfig::paramName(GMBH_STREET), dbConfig::readValue(GMBH_STREET));
+    setField(dbConfig::paramName(GMBH_PLZ), dbConfig::readValue(GMBH_PLZ));
+    setField(dbConfig::paramName(GMBH_CITY), dbConfig::readValue(GMBH_CITY));
+    setField(dbConfig::paramName(GMBH_EMAIL), dbConfig::readValue(GMBH_EMAIL));
+    setField(dbConfig::paramName(GMBH_URL), dbConfig::readValue(GMBH_URL));
 }
 
-wpProjectDetails_Page::wpProjectDetails_Page(QWidget* p) : QWizardPage(p)
+wpProjectDetails_Page::wpProjectDetails_Page(QWidget *p) : QWizardPage(p)
 {
     setTitle(qsl("Weitere Daten der Projekt GmbH"));
-    setSubTitle(qsl("*<small>Diese Daten werden für Briefdruck benötigt und können auch später eingegeben und geändert werden.</small>"));
-    QLabel* lHre = new QLabel (qsl("Eintrag im Handeslregister"));
-    QLineEdit* leHre = new QLineEdit;
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("*<small>Diese Daten werden für Briefdruck benötigt und können auch später eingegeben und geändert werden.</small>"));
+    QLabel *lHre = new QLabel(qsl("Eintrag im Handeslregister"));
+    QLineEdit *leHre = new QLineEdit;
     registerField(dbConfig::paramName(GMBH_HRE), leHre);
     leHre->setToolTip(qsl("Gib hier an, wie der Handelsregistereintrag der GmbH lautet."));
-    QLabel* lGefue = new QLabel (qsl("Geschäftsführer*innen"));
-    QLineEdit* leGefue1 = new QLineEdit;
+    QLabel *lGefue = new QLabel(qsl("Geschäftsführer*innen"));
+    QLineEdit *leGefue1 = new QLineEdit;
     registerField(dbConfig::paramName(GMBH_GEFUE1), leGefue1);
     leGefue1->setToolTip(qsl("Gib hier den Namen eines Geschäftsführers oder einer Geschäftsführerin ein."));
-    QLineEdit* leGefue2 = new QLineEdit;
+    QLineEdit *leGefue2 = new QLineEdit;
     registerField(dbConfig::paramName(GMBH_GEFUE2), leGefue2);
     leGefue2->setToolTip(qsl("Gib hier den Namen eines Geschäftsführers oder einer Geschäftsführerin ein."));
-    QLineEdit* leGefue3 = new QLineEdit;
+    QLineEdit *leGefue3 = new QLineEdit;
     registerField(dbConfig::paramName(GMBH_GEFUE3), leGefue3);
     leGefue3->setToolTip(qsl("Gib hier den Namen eines Geschäftsführers oder einer Geschäftsführerin ein."));
-    QLabel* lDkv =new QLabel(qsl("DK Verwaltung"));
-    QLineEdit* leDkv = new QLineEdit;
+    QLabel *lDkv = new QLabel(qsl("DK Verwaltung"));
+    QLineEdit *leDkv = new QLineEdit;
     registerField(dbConfig::paramName(GMBH_DKV), leDkv);
     leDkv->setToolTip(qsl("Gib hier ein, wer bei Euch die Briefe der DK Verwaltung erstellt."));
 
-    QGridLayout* grid  = new QGridLayout;
-    grid->addWidget(lHre,     0, 0, 1, 2);
-    grid->addWidget(leHre,    0, 2, 1, 3);
-    grid->addWidget(lGefue,   1, 0, 1, 2);
-    grid->addWidget(leGefue1, 1, 2, 1, 3);
-    grid->addWidget(leGefue2, 2, 2, 1, 3);
-    grid->addWidget(leGefue3, 3, 2, 1, 3);
-    grid->addWidget(lDkv,     4, 0, 1, 2);
-    grid->addWidget(leDkv,    4, 2, 1, 3);
+    QGridLayout *grid = new QGridLayout;
+    int row = 0;
+    grid->addWidget(subTitleLabel, row, 0, 1, 4);
+    row++;
+    grid->addWidget(lHre, row, 0, 1, 2);
+    grid->addWidget(leHre, row, 2, 1, 3);
+    row++;
+    grid->addWidget(lGefue, row, 0, 1, 2);
+    grid->addWidget(leGefue1, row, 2, 1, 3);
+    row++;
+    grid->addWidget(leGefue2, row, 2, 1, 3);
+    row++;
+    grid->addWidget(leGefue3, row, 2, 1, 3);
+    row++;
+    grid->addWidget(lDkv, row, 0, 1, 2);
+    grid->addWidget(leDkv, row, 2, 1, 3);
     grid->setColumnStretch(0, 2);
     grid->setColumnStretch(3, 3);
     setLayout(grid);
@@ -191,31 +228,33 @@ wpProjectDetails_Page::wpProjectDetails_Page(QWidget* p) : QWizardPage(p)
 
 void wpProjectDetails_Page::initializePage()
 {
-    setField(dbConfig::paramName(GMBH_HRE),    dbConfig::readValue(GMBH_HRE));
+    setField(dbConfig::paramName(GMBH_HRE), dbConfig::readValue(GMBH_HRE));
     setField(dbConfig::paramName(GMBH_GEFUE1), dbConfig::readValue(GMBH_GEFUE1));
     setField(dbConfig::paramName(GMBH_GEFUE2), dbConfig::readValue(GMBH_GEFUE2));
     setField(dbConfig::paramName(GMBH_GEFUE3), dbConfig::readValue(GMBH_GEFUE3));
-    setField(dbConfig::paramName(GMBH_DKV),    dbConfig::readValue(GMBH_DKV));
+    setField(dbConfig::paramName(GMBH_DKV), dbConfig::readValue(GMBH_DKV));
 }
 
-wpContractLableInfo_Page::wpContractLableInfo_Page(QWidget* p) : QWizardPage(p)
+wpContractLableInfo_Page::wpContractLableInfo_Page(QWidget *p) : QWizardPage(p)
 {
     setTitle(qsl("Vertragskennung"));
-    setSubTitle(qsl("Diese Informationen werden verwendet um eindeutige Kennzeichen für die einzelnen Verträge zu erzeugen"));
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("Diese Informationen werden verwendet um eindeutige Kennzeichen für die einzelnen Verträge zu erzeugen"));
 
-    QLabel* lProject= new QLabel(qsl("Projekt Kürzel (2-5 Zeichen):"));
-    QLineEdit* leProject = new QLineEdit;
+    QLabel *lProject = new QLabel(qsl("Projekt Kürzel (2-5 Zeichen):"));
+    QLineEdit *leProject = new QLineEdit;
     lProject->setBuddy(leProject);
     registerField(dbConfig::paramName(GMBH_INITIALS), leProject);
     leProject->setToolTip(qsl("Das Kürzel wird bei der Erstellung von Vertragskennzeichen verwendet"));
 
-    QLabel* lIndex = new QLabel(qsl("Start Index:"));
+    QLabel *lIndex = new QLabel(qsl("Start Index:"));
     leStartIndex = new QLineEdit;
     lIndex->setBuddy(leStartIndex);
     registerField(dbConfig::paramName(STARTINDEX), leStartIndex);
     lIndex->setToolTip(qsl("Mit diesem Index beginnt die laufende Nummer in den Vertragskennzeichen"));
 
-    QVBoxLayout* layout =new QVBoxLayout;
+    QVBoxLayout *layout = new QVBoxLayout;
+    layout->addWidget(subTitleLabel);
     layout->addWidget(lProject);
     layout->addWidget(leProject);
     layout->addWidget(lIndex);
@@ -236,58 +275,66 @@ bool wpContractLableInfo_Page::validatePage()
     int startindex = field(dbConfig::paramName(STARTINDEX)).toInt();
     setField(dbConfig::paramName(STARTINDEX), QString::number(startindex));
     QString project = field(dbConfig::paramName(GMBH_INITIALS)).toString();
-    if(project.length()> 5)
+    if (project.length() > 5)
         setField(dbConfig::paramName(GMBH_INITIALS), project.left(5));
     return true;
 }
 
-wpContractMinValues_Page:: wpContractMinValues_Page(QWidget* p) : QWizardPage(p)
+wpContractMinValues_Page::wpContractMinValues_Page(QWidget *p) : QWizardPage(p)
 {
     setTitle(qsl("Weitere Konfiguration"));
-    setSubTitle(qsl("Hier kannst Du den minimalen Auszahlungsbetrag und Vertragswert festlegen, für den das Programm eine Buchung erlaubt. "
-                "Dieser Werte werden bei Auszahlungen und beim Anlegen von Verträgen berücksichtigt.<p>"
-                "<small>Da Auszahlungen z.T. mit Überweisungskosten einhergehen und kleine Verträge unrentabel sind sollte man kleine Werte vermeiden.</small>"));
-    leMa =new QLineEdit;
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("Hier kannst Du den minimalen Auszahlungsbetrag und Vertragswert festlegen, für den das Programm eine Buchung erlaubt. "
+                               "Dieser Werte werden bei Auszahlungen und beim Anlegen von Verträgen berücksichtigt.<p>"
+                               "<small>Da Auszahlungen z.T. mit Überweisungskosten einhergehen und kleine Verträge unrentabel sind sollte man kleine Werte vermeiden.</small>"));
+    leMa = new QLineEdit;
     registerField(dbConfig::paramName(MIN_PAYOUT), leMa);
-    leMa->setValidator(new QIntValidator(1,1000,this));
-    QLabel* lma     =new QLabel(qsl("Kleinster Auszahlungsbetrag in Euro:"));
+    leMa->setValidator(new QIntValidator(1, 1000, this));
+    QLabel *lma = new QLabel(qsl("Kleinster Auszahlungsbetrag in Euro:"));
     lma->setBuddy(leMa);
 
-    leMc =new QLineEdit;
+    leMc = new QLineEdit;
     registerField(dbConfig::paramName(MIN_AMOUNT), leMc);
-    leMc->setValidator(new QIntValidator(1,1000, this));
-    QLabel* lmc     =new QLabel(qsl("Kleinster Vertragswert in Euro:"));
+    leMc->setValidator(new QIntValidator(1, 1000, this));
+    QLabel *lmc = new QLabel(qsl("Kleinster Vertragswert in Euro:"));
     lmc->setBuddy(leMc);
 
-    leMi =new QLineEdit;
+    leMi = new QLineEdit;
     registerField(dbConfig::paramName(MAX_INTEREST), leMi);
     leMi->setValidator(new QIntValidator(100, 1000, this));
-    QLabel* lmi     =new QLabel(qsl("Größter auswählbarer Zins in 100tel (100 entspricht 1%)"));
+    QLabel *lmi = new QLabel(qsl("Größter auswählbarer Zins in 100tel (100 entspricht 1%)"));
     lmi->setBuddy(leMi);
 
-    leMaxINbr =new QLineEdit;
+    leMaxINbr = new QLineEdit;
     registerField(dbConfig::paramName(MAX_INVESTMENT_NBR), leMaxINbr);
     leMaxINbr->setValidator(new QIntValidator(1, 100, this));
-    QLabel* lmaxINbr =new QLabel(qsl("Ansahl von Verträgen in einem Investment ab der sie rot gekennzeichnet wird"));
+    QLabel *lmaxINbr = new QLabel(qsl("Ansahl von Verträgen in einem Investment ab der sie rot gekennzeichnet wird"));
     lmaxINbr->setBuddy(leMaxINbr);
 
-    leMaxISum =new QLineEdit;
+    leMaxISum = new QLineEdit;
     registerField(dbConfig::paramName(MAX_INVESTMENT_SUM), leMaxISum);
     leMaxISum->setValidator(new QIntValidator(1, 1000000, this));
-    QLabel* lmaxISum =new QLabel(qsl("Summe aller Verträge in einem Investment ab der sie rot gekennzeichnet wird"));
+    QLabel *lmaxISum = new QLabel(qsl("Summe aller Verträge in einem Investment ab der sie rot gekennzeichnet wird"));
     lmaxISum->setBuddy(leMaxISum);
 
-    QGridLayout* grid =new QGridLayout;
-    grid->addWidget(lma,  0, 0);
-    grid->addWidget(leMa, 0, 1);
-    grid->addWidget(lmc,  1, 0);
-    grid->addWidget(leMc, 1, 1);
-    grid->addWidget(lmi,  2, 0);
-    grid->addWidget(leMi, 2, 1);
-    grid->addWidget(lmaxINbr, 3, 0);
-    grid->addWidget(leMaxINbr, 3, 1);
-    grid->addWidget(lmaxISum, 4, 0);
-    grid->addWidget(leMaxISum, 4, 1);
+    QGridLayout *grid = new QGridLayout;
+    int row = 0;
+    grid->addWidget(subTitleLabel, row, 0, 1, 2);
+    row++;
+    grid->addWidget(lma, row, 0);
+    grid->addWidget(leMa, row, 1);
+    row++;
+    grid->addWidget(lmc, row, 0);
+    grid->addWidget(leMc, row, 1);
+    row++;
+    grid->addWidget(lmi, row, 0);
+    grid->addWidget(leMi, row, 1);
+    row++;
+    grid->addWidget(lmaxINbr, row, 0);
+    grid->addWidget(leMaxINbr, row, 1);
+    row++;
+    grid->addWidget(lmaxISum, row, 0);
+    grid->addWidget(leMaxISum, row, 1);
     setLayout(grid);
 }
 
@@ -302,30 +349,28 @@ void wpContractMinValues_Page::initializePage()
 
 bool wpContractMinValues_Page::validatePage()
 {
-    return leMa->hasAcceptableInput() and leMc->hasAcceptableInput()
-            and leMi->hasAcceptableInput() and leMaxINbr->hasAcceptableInput()
-            and leMaxISum->hasAcceptableInput();
+    return leMa->hasAcceptableInput() and leMc->hasAcceptableInput() and leMi->hasAcceptableInput() and leMaxINbr->hasAcceptableInput() and leMaxISum->hasAcceptableInput();
 }
 
-
-wpNewDatabase_SummaryPage::wpNewDatabase_SummaryPage(QWidget* p) : QWizardPage(p)
+wpNewDatabase_SummaryPage::wpNewDatabase_SummaryPage(QWidget *p) : QWizardPage(p)
 {
     setTitle(qsl("Zusammenfassung"));
-    QCheckBox* cb = new QCheckBox(qsl("Die Eingaben sind korrekt!"));
+    QCheckBox *cb = new QCheckBox(qsl("Die Eingaben sind korrekt!"));
     registerField(qsl("confirmed"), cb);
     cb->setToolTip(qsl("Mit diesem Ankreuzfeld bestätigst Du, dass die Angaben richtig sind."));
-    QVBoxLayout* layout = new QVBoxLayout;
-    layout-> addWidget(cb);
+    QVBoxLayout *layout = new QVBoxLayout;
+    layout->addWidget(subTitleLabel);
+    layout->addWidget(cb);
     setLayout(layout);
     connect(cb, &QCheckBox::stateChanged, this, &wpNewDatabase_SummaryPage::onConfirmData_toggled);
 }
 void wpNewDatabase_SummaryPage::initializePage()
 {
     QString subt = qsl("<b>Projekt Daten:</b>"
-                   "<table><tr><td>Adresse:</td><td>%1</td></tr>"
-                   "<tr><td></td><td>%2</td></tr>"
-                   "<tr><td></td><td>%3</td></tr>"
-                   "<tr><td></td><td>%4 %5<br></td></tr>");
+                       "<table><tr><td>Adresse:</td><td>%1</td></tr>"
+                       "<tr><td></td><td>%2</td></tr>"
+                       "<tr><td></td><td>%3</td></tr>"
+                       "<tr><td></td><td>%4 %5<br></td></tr>");
     subt = subt.arg(field(dbConfig::paramName(GMBH_ADDRESS1)).toString());
     subt = subt.arg(field(dbConfig::paramName(GMBH_ADDRESS2)).toString());
     subt = subt.arg(field(dbConfig::paramName(GMBH_STREET)).toString());
@@ -333,13 +378,13 @@ void wpNewDatabase_SummaryPage::initializePage()
     subt = subt.arg(field(dbConfig::paramName(GMBH_CITY)).toString());
 
     subt += qsl("<tr><td>E-Mail:</td><td>%1</td></tr>"
-            "<tr><td>Web:</td><td>%2</td></tr>"
-            "<tr><td>Kürzel:    </td><td>%3</td></tr>"
-            "<tr><td>Start Index:&nbsp;&nbsp;</td><td>%4</td></tr></table>");
+                "<tr><td>Web:</td><td>%2</td></tr>"
+                "<tr><td>Kürzel:    </td><td>%3</td></tr>"
+                "<tr><td>Start Index:&nbsp;&nbsp;</td><td>%4</td></tr></table>");
     subt = subt.arg(field(dbConfig::paramName(GMBH_EMAIL)).toString(), field(dbConfig::paramName(GMBH_URL)).toString());
     subt = subt.arg(field(dbConfig::paramName(GMBH_INITIALS)).toString());
     subt = subt.arg(field(dbConfig::paramName(STARTINDEX)).toString());
-    setSubTitle(subt);
+    subTitleLabel->setText(subt);
 }
 void wpNewDatabase_SummaryPage::onConfirmData_toggled(int)
 {
@@ -353,23 +398,27 @@ bool wpNewDatabase_SummaryPage::isComplete() const
 /*
  * newDb wizard: filename, GmbH data, db data
 */
-wizConfigureNewDatabaseWiz::wizConfigureNewDatabaseWiz(QWidget* p) : QWizard(p) {
+wizConfigureNewDatabaseWiz::wizConfigureNewDatabaseWiz(QWidget *p) : QWizard(p)
+{
     addPage(new wpFileSelectionNewDb_IntroPage);
     addPage(new wpProjectAddress_Page);
     addPage(new wpProjectDetails_Page);
     addPage(new wpContractMinValues_Page);
     addPage(new wpContractLableInfo_Page);
     addPage(new wpNewDatabase_SummaryPage);
-    QFont f = font(); f.setPointSize(10); setFont(f);
+    QFont f = font();
+    f.setPointSize(10);
+    setFont(f);
 }
 
 void wizConfigureNewDatabaseWiz::updateDbConfig(const QString &dbFile)
 {
     LOG_CALL;
-    dbCloser closer{ qsl("updateDbConfig") };
+    dbCloser closer{qsl("updateDbConfig")};
     QSqlDatabase db = QSqlDatabase::addDatabase(dbTypeName, closer.conName);
     db.setDatabaseName(dbFile);
-    if( not db.open()) {
+    if (not db.open())
+    {
         qCritical() << "failed to open db" << db.lastError();
         return;
     }
@@ -378,65 +427,73 @@ void wizConfigureNewDatabaseWiz::updateDbConfig(const QString &dbFile)
 }
 
 void wizConfigureNewDatabaseWiz::updateDbConfig(const QSqlDatabase &db)
-{   LOG_CALL;
-    dbConfig::writeValue(GMBH_ADDRESS1,  field(dbConfig::paramName(GMBH_ADDRESS1)), db);
-    dbConfig::writeValue(GMBH_ADDRESS2,  field(dbConfig::paramName(GMBH_ADDRESS2)), db);
-    dbConfig::writeValue(GMBH_STREET,    field(dbConfig::paramName(GMBH_STREET  )), db);
-    dbConfig::writeValue(GMBH_PLZ ,      field(dbConfig::paramName(GMBH_PLZ)), db);
-    dbConfig::writeValue(GMBH_CITY ,     field(dbConfig::paramName(GMBH_CITY)), db);
-    dbConfig::writeValue(GMBH_EMAIL ,    field(dbConfig::paramName(GMBH_EMAIL)), db);
-    dbConfig::writeValue(GMBH_URL ,      field(dbConfig::paramName(GMBH_URL)), db);
-    dbConfig::writeValue(GMBH_INITIALS , field(dbConfig::paramName(GMBH_INITIALS)), db);
-    dbConfig::writeValue(STARTINDEX ,    field(dbConfig::paramName(STARTINDEX)), db);
-    dbConfig::writeValue(DBID,  QVariant(dbConfig::readValue(GMBH_INITIALS).toString() +dbConfig::readValue(STARTINDEX).toString()), db);
-    dbConfig::writeValue(GMBH_HRE,     field(dbConfig::paramName(GMBH_HRE)), db);
-    dbConfig::writeValue(GMBH_GEFUE1,  field(dbConfig::paramName(GMBH_GEFUE1)), db);
-    dbConfig::writeValue(GMBH_GEFUE2,  field(dbConfig::paramName(GMBH_GEFUE2)), db);
-    dbConfig::writeValue(GMBH_GEFUE3,  field(dbConfig::paramName(GMBH_GEFUE3)), db);
-    dbConfig::writeValue(GMBH_DKV,     field(dbConfig::paramName(GMBH_DKV)), db);
-    dbConfig::writeValue(MIN_PAYOUT,   field(dbConfig::paramName(MIN_PAYOUT)), db);
-    dbConfig::writeValue(MIN_AMOUNT,   field(dbConfig::paramName(MIN_AMOUNT)), db);
+{
+    LOG_CALL;
+    dbConfig::writeValue(GMBH_ADDRESS1, field(dbConfig::paramName(GMBH_ADDRESS1)), db);
+    dbConfig::writeValue(GMBH_ADDRESS2, field(dbConfig::paramName(GMBH_ADDRESS2)), db);
+    dbConfig::writeValue(GMBH_STREET, field(dbConfig::paramName(GMBH_STREET)), db);
+    dbConfig::writeValue(GMBH_PLZ, field(dbConfig::paramName(GMBH_PLZ)), db);
+    dbConfig::writeValue(GMBH_CITY, field(dbConfig::paramName(GMBH_CITY)), db);
+    dbConfig::writeValue(GMBH_EMAIL, field(dbConfig::paramName(GMBH_EMAIL)), db);
+    dbConfig::writeValue(GMBH_URL, field(dbConfig::paramName(GMBH_URL)), db);
+    dbConfig::writeValue(GMBH_INITIALS, field(dbConfig::paramName(GMBH_INITIALS)), db);
+    dbConfig::writeValue(STARTINDEX, field(dbConfig::paramName(STARTINDEX)), db);
+    dbConfig::writeValue(DBID, QVariant(dbConfig::readValue(GMBH_INITIALS).toString() + dbConfig::readValue(STARTINDEX).toString()), db);
+    dbConfig::writeValue(GMBH_HRE, field(dbConfig::paramName(GMBH_HRE)), db);
+    dbConfig::writeValue(GMBH_GEFUE1, field(dbConfig::paramName(GMBH_GEFUE1)), db);
+    dbConfig::writeValue(GMBH_GEFUE2, field(dbConfig::paramName(GMBH_GEFUE2)), db);
+    dbConfig::writeValue(GMBH_GEFUE3, field(dbConfig::paramName(GMBH_GEFUE3)), db);
+    dbConfig::writeValue(GMBH_DKV, field(dbConfig::paramName(GMBH_DKV)), db);
+    dbConfig::writeValue(MIN_PAYOUT, field(dbConfig::paramName(MIN_PAYOUT)), db);
+    dbConfig::writeValue(MIN_AMOUNT, field(dbConfig::paramName(MIN_AMOUNT)), db);
     dbConfig::writeValue(MAX_INTEREST, field(dbConfig::paramName(MAX_INTEREST)), db);
-    dbConfig::writeValue(MAX_INVESTMENT_NBR,field(dbConfig::paramName(MAX_INVESTMENT_NBR)), db);
-    dbConfig::writeValue(MAX_INVESTMENT_SUM,field(dbConfig::paramName(MAX_INVESTMENT_SUM)), db);
+    dbConfig::writeValue(MAX_INVESTMENT_NBR, field(dbConfig::paramName(MAX_INVESTMENT_NBR)), db);
+    dbConfig::writeValue(MAX_INVESTMENT_SUM, field(dbConfig::paramName(MAX_INVESTMENT_SUM)), db);
 }
 
-wpConfigure_IntroPage::wpConfigure_IntroPage(QWidget* p) : QWizardPage(p)
+wpConfigure_IntroPage::wpConfigure_IntroPage(QWidget *p) : QWizardPage(p)
 {
     setTitle(qsl("Konfiguration"));
-    setSubTitle(qsl("Mit dieser Dialogfolge kannst du Konfigurationen "
-                "für Briefdruck und die Datenbank vornehmen."));
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("Mit dieser Dialogfolge kannst du Konfigurationen "
+                    "für Briefdruck und die Datenbank vornehmen."));
+    QVBoxLayout *layout = new QVBoxLayout;
+    layout->addWidget(subTitleLabel);
+    setLayout(layout);
 }
 
 /*
  * newDb wizard: filename, GmbH data, db data
 */
-wizConfigureProjectWiz::wizConfigureProjectWiz(QWidget* p) : QWizard(p) {
+wizConfigureProjectWiz::wizConfigureProjectWiz(QWidget *p) : QWizard(p)
+{
     addPage(new wpConfigure_IntroPage);
     addPage(new wpProjectAddress_Page);
     addPage(new wpProjectDetails_Page);
     addPage(new wpContractMinValues_Page);
-    QFont f =font(); f.setPointSize(10); setFont(f);
+    QFont f = font();
+    f.setPointSize(10);
+    setFont(f);
 }
 void wizConfigureProjectWiz::updateDbConfig()
-{   LOG_CALL;
-    dbConfig::writeValue(GMBH_ADDRESS1,  field(dbConfig::paramName(GMBH_ADDRESS1)));
-    dbConfig::writeValue(GMBH_ADDRESS2,  field(dbConfig::paramName(GMBH_ADDRESS2)));
-    dbConfig::writeValue(GMBH_STREET,    field(dbConfig::paramName(GMBH_STREET  )));
-    dbConfig::writeValue(GMBH_PLZ ,      field(dbConfig::paramName(GMBH_PLZ)));
-    dbConfig::writeValue(GMBH_CITY ,     field(dbConfig::paramName(GMBH_CITY)));
-    dbConfig::writeValue(GMBH_EMAIL ,    field(dbConfig::paramName(GMBH_EMAIL)));
-    dbConfig::writeValue(GMBH_URL ,      field(dbConfig::paramName(GMBH_URL)));
+{
+    LOG_CALL;
+    dbConfig::writeValue(GMBH_ADDRESS1, field(dbConfig::paramName(GMBH_ADDRESS1)));
+    dbConfig::writeValue(GMBH_ADDRESS2, field(dbConfig::paramName(GMBH_ADDRESS2)));
+    dbConfig::writeValue(GMBH_STREET, field(dbConfig::paramName(GMBH_STREET)));
+    dbConfig::writeValue(GMBH_PLZ, field(dbConfig::paramName(GMBH_PLZ)));
+    dbConfig::writeValue(GMBH_CITY, field(dbConfig::paramName(GMBH_CITY)));
+    dbConfig::writeValue(GMBH_EMAIL, field(dbConfig::paramName(GMBH_EMAIL)));
+    dbConfig::writeValue(GMBH_URL, field(dbConfig::paramName(GMBH_URL)));
 
-    dbConfig::writeValue(GMBH_HRE,     field(dbConfig::paramName(GMBH_HRE)));
-    dbConfig::writeValue(GMBH_GEFUE1,  field(dbConfig::paramName(GMBH_GEFUE1)));
-    dbConfig::writeValue(GMBH_GEFUE2,  field(dbConfig::paramName(GMBH_GEFUE2)));
-    dbConfig::writeValue(GMBH_GEFUE3,  field(dbConfig::paramName(GMBH_GEFUE3)));
-    dbConfig::writeValue(GMBH_DKV,     field(dbConfig::paramName(GMBH_DKV)));
-    dbConfig::writeValue(MIN_PAYOUT,   field(dbConfig::paramName(MIN_PAYOUT)));
-    dbConfig::writeValue(MIN_AMOUNT,   field(dbConfig::paramName(MIN_AMOUNT)));
+    dbConfig::writeValue(GMBH_HRE, field(dbConfig::paramName(GMBH_HRE)));
+    dbConfig::writeValue(GMBH_GEFUE1, field(dbConfig::paramName(GMBH_GEFUE1)));
+    dbConfig::writeValue(GMBH_GEFUE2, field(dbConfig::paramName(GMBH_GEFUE2)));
+    dbConfig::writeValue(GMBH_GEFUE3, field(dbConfig::paramName(GMBH_GEFUE3)));
+    dbConfig::writeValue(GMBH_DKV, field(dbConfig::paramName(GMBH_DKV)));
+    dbConfig::writeValue(MIN_PAYOUT, field(dbConfig::paramName(MIN_PAYOUT)));
+    dbConfig::writeValue(MIN_AMOUNT, field(dbConfig::paramName(MIN_AMOUNT)));
     dbConfig::writeValue(MAX_INTEREST, field(dbConfig::paramName(MAX_INTEREST)));
-    dbConfig::writeValue(MAX_INVESTMENT_NBR,field(dbConfig::paramName(MAX_INVESTMENT_NBR)));
-    dbConfig::writeValue(MAX_INVESTMENT_SUM,field(dbConfig::paramName(MAX_INVESTMENT_SUM)));
+    dbConfig::writeValue(MAX_INVESTMENT_NBR, field(dbConfig::paramName(MAX_INVESTMENT_NBR)));
+    dbConfig::writeValue(MAX_INVESTMENT_SUM, field(dbConfig::paramName(MAX_INVESTMENT_SUM)));
 }
-

--- a/DKV2/wiznewdatabase.h
+++ b/DKV2/wiznewdatabase.h
@@ -5,6 +5,7 @@
 #include <QStringLiteral>
 #include <QLineEdit>
 #include <QWizard>
+#include <QLabel>
 
 #include "helper.h"
 
@@ -19,6 +20,9 @@ public:
     bool validatePage() override;
 private slots:
     void browseButtonClicked();
+
+private:
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 /* database -> open WIZ */
 class wizFileSelectionWiz : public QWizard
@@ -42,6 +46,9 @@ class wpFileSelectionNewDb_IntroPage : public QWizardPage
 public:
     wpFileSelectionNewDb_IntroPage(QWidget* p =nullptr);
     void initializePage() override;
+
+private:
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 /* project address Page */
 class wpProjectAddress_Page : public QWizardPage
@@ -53,6 +60,8 @@ public:
     void cleanupPage() override  {};
 //    void setVisible(bool v) override;
 //    bool validatePage() override;
+private:
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 /* project Details Page */
 struct wpProjectDetails_Page : public QWizardPage
@@ -61,6 +70,9 @@ struct wpProjectDetails_Page : public QWizardPage
     void cleanupPage() override  {};
     void initializePage() override;
     Q_OBJECT;
+
+private:
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 /* contract label Page */
 class wpContractLableInfo_Page : public QWizardPage
@@ -74,6 +86,7 @@ public:
 //    void disableStartIndex() { leStartIndex->setDisabled(true);};
 private:
     QLineEdit* leStartIndex;
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 /* min values Page */
 class wpContractMinValues_Page : public QWizardPage
@@ -90,6 +103,7 @@ private:
     QLineEdit* leMi =nullptr;
     QLineEdit* leMaxINbr =nullptr;
     QLineEdit* leMaxISum =nullptr;
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 /* new db summary Page */
 class wpNewDatabase_SummaryPage : public QWizardPage{
@@ -100,6 +114,9 @@ public:
     bool isComplete() const override;
 public slots:
     void onConfirmData_toggled(int);
+
+private:
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 /* project address WIZ */
 struct wizConfigureNewDatabaseWiz : public QWizard
@@ -108,6 +125,9 @@ struct wizConfigureNewDatabaseWiz : public QWizard
     void updateDbConfig(const QString &dbFile);
     void updateDbConfig(const QSqlDatabase &db=QSqlDatabase::database());
     Q_OBJECT;
+
+private:
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 /* configure project intro PAGE*/
 class wpConfigure_IntroPage : public QWizardPage
@@ -116,6 +136,8 @@ class wpConfigure_IntroPage : public QWizardPage
 public:
     wpConfigure_IntroPage(QWidget* p =nullptr);
     // void initializePage() override;
+private:
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 /* project config WIZ*/
 class wizConfigureProjectWiz : public QWizard

--- a/DKV2/wiznewinvestment.cpp
+++ b/DKV2/wiznewinvestment.cpp
@@ -19,12 +19,13 @@ const QString pnKorrekt =qsl("OK");
 wpInvestmentSummary::wpInvestmentSummary(QWidget* w) : QWizardPage(w)
 {   LOG_CALL;
     setTitle(qsl("Zusammenfassung"));
-    setSubTitle(qsl("Bitte prüfe die Daten"));
+    subTitleLabel->setText(qsl("Bitte prüfe die Daten"));
 
     QCheckBox* cb =new QCheckBox(qsl("Die Angaben sind korrekt"));
     registerField(pnKorrekt+qsl("*"), cb);
 
     QVBoxLayout* vl =new QVBoxLayout();
+    vl->addWidget(subTitleLabel);
     vl->addWidget(cb);
     setLayout(vl);
 }
@@ -39,7 +40,8 @@ void wpInvestmentSummary::initializePage()
     msg =msg.arg(field(pnVon).toDate().toString(qsl("dd.MM.yyyy")));
     msg =msg.arg(field(pnBis).toDate().toString(qsl("dd.MM.yyyy")));
     msg =msg.arg(field(pnTyp).toString());
-    setSubTitle(msg);
+    subTitleLabel->setText(msg);
+    subTitleLabel->setWordWrap(true);
 }
 /* ////////////////////////////
   wpType
@@ -47,16 +49,20 @@ void wpInvestmentSummary::initializePage()
 wpType::wpType(QWidget* w) : QWizardPage(w)
 {   LOG_CALL;
     setTitle(qsl("Titel/Name der Anlage"));
-    setTitle(qsl("Gib einen verständlichen Namen für diese Art der Anlage ein"));
-    QLabel* l =new QLabel(qsl("Anlage Typ"));
+    subTitleLabel->setText(qsl("Gib einen verständlichen Namen für diese Art der Anlage ein"));
+    subTitleLabel->setWordWrap(true);
+    QLabel *l = new QLabel(qsl("Anlage Typ"));
     l->setToolTip(qsl("Kurzbeschreibung der Anlage"));
     QLineEdit* le =new QLineEdit();
     l->setBuddy(le);
     le->setToolTip(l->toolTip());
     registerField(pnTyp, le);
-    QHBoxLayout* layout =new QHBoxLayout();
-    layout->addWidget(l);
-    layout->addWidget(le);
+    QHBoxLayout *lh = new QHBoxLayout();
+    lh->addWidget(l);
+    lh->addWidget(le);
+    QVBoxLayout *layout = new QVBoxLayout();
+    layout->addWidget(subTitleLabel);
+    layout->addLayout(lh);
     setLayout(layout);
 }
 void wpType::initializePage()
@@ -71,7 +77,8 @@ void wpType::initializePage()
 wpTimeFrame::wpTimeFrame(QWidget* w) : QWizardPage(w)
 {   LOG_CALL;
     setTitle(qsl("Ausgabedauer"));
-    setSubTitle(qsl("Gib an, in welchem Zeitfenster Verträge zu dieser Anlage gezählt werden."));
+    subTitleLabel->setText(qsl("Gib an, in welchem Zeitfenster Verträge zu dieser Anlage gezählt werden."));
+    subTitleLabel->setWordWrap(true);
 
     QLabel* lVon =new QLabel(qsl("Erstausgabe"));
     lVon->setToolTip(qsl("Verträge mit dem zuvor angegebenen Zinssatz werden ab diesem Datum zu der Geldanlage gezählt"));
@@ -93,10 +100,12 @@ wpTimeFrame::wpTimeFrame(QWidget* w) : QWizardPage(w)
     connect(deVon, &QDateTimeEdit::dateChanged, this, &wpTimeFrame::onStartDate_changed);
 
     QHBoxLayout* hlVon =new QHBoxLayout();
-    hlVon->addWidget(lVon); hlVon->addWidget(deVon);
+    hlVon->addWidget(lVon);
+    hlVon->addWidget(deVon);
     QHBoxLayout* hlBis =new QHBoxLayout();
     hlBis->addWidget(lBis); hlBis->addWidget(deBis);
     QVBoxLayout* vl =new QVBoxLayout();
+    vl->addWidget(subTitleLabel);
     vl->addLayout(hlVon);
     vl->addLayout(hlBis);
     setLayout(vl);
@@ -121,7 +130,9 @@ void wpTimeFrame::onStartDate_changed()
 wpNewInvestInterest::wpNewInvestInterest(QWidget* p) : QWizardPage(p)
 {   LOG_CALL;
     setTitle(qsl("Geldanlage festlegen"));
-    setSubTitle(qsl("Mit dieser Dialogfolge kannst Du eine Geldanlage definieren. Gib zunächst den Zinssatz der Geldanlage ein."));
+    subTitleLabel->setText(qsl("Mit dieser Dialogfolge kannst Du eine Geldanlage definieren. "
+                                "Gib zunächst den Zinssatz der Geldanlage ein.<p>"));
+    subTitleLabel->setWordWrap(true);
 
     QLabel* lZinssatz =new QLabel(qsl("Zinssatz"));
 
@@ -133,9 +144,12 @@ wpNewInvestInterest::wpNewInvestInterest(QWidget* p) : QWizardPage(p)
         cbInterest->addItem(QString::number(i/100., 'f', 2), QVariant(i));
     cbInterest->setCurrentIndex(std::min(90, cbInterest->count()));
     cbInterest->setToolTip(qsl("Verträge mit diesem Zinssatz werden zu dieser Geldanlage gehören."));
-    QHBoxLayout* layout =new QHBoxLayout();
-    layout->addWidget(lZinssatz);
-    layout->addWidget(cbInterest);
+    QGridLayout* layout =new QGridLayout();
+    layout->addWidget(subTitleLabel, 0, 0, 1, 3);
+    layout->addWidget(lZinssatz, 1, 0, 2, 1);
+    layout->addWidget(cbInterest, 1, 1, 1, 1);
+    layout->setColumnStretch(0, 1);
+    layout->setColumnStretch(2, 2);
     setLayout(layout);
 }
 

--- a/DKV2/wiznewinvestment.h
+++ b/DKV2/wiznewinvestment.h
@@ -3,6 +3,7 @@
 
 #include <QWizard>
 #include <QComboBox>
+#include <QLabel>
 
 #include "investment.h"
 
@@ -19,6 +20,8 @@ public:
     wpInvestmentSummary(QWidget* w =nullptr);
     void initializePage() override;
 //    bool validatePage() override;
+private:
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 struct wpType : public QWizardPage
@@ -28,6 +31,8 @@ public:
     wpType(QWidget* p =nullptr);
     void initializePage() override;
 //    bool validatePage() override;
+private:
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 class wpTimeFrame : public QWizardPage
@@ -39,6 +44,9 @@ public:
     bool validatePage() override;
 private slots:
     void onStartDate_changed();
+
+private:
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 struct wpNewInvestInterest : public QWizardPage
@@ -48,6 +56,7 @@ struct wpNewInvestInterest : public QWizardPage
     // bool validatePage() override;
 private:
     Q_OBJECT;
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 struct wizNewInvestment : public QWizard

--- a/DKV2/wizopenornewdatabase.cpp
+++ b/DKV2/wizopenornewdatabase.cpp
@@ -14,14 +14,17 @@
 wpOpenOrNew::wpOpenOrNew(QWidget* p) : QWizardPage(p)
 {   LOG_CALL;
     setTitle(qsl("Datenbank Auswahl"));
-    setSubTitle(qsl("Mit dieser Dialogfolge kann die Datenbank zum Speichern der Kreditdaten gewählt werden."));
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("Mit dieser Dialogfolge kann die Datenbank zum Speichern der Kreditdaten gewählt werden."));
     QRadioButton* rbNew  = new QRadioButton(qsl("Neue Datenbank anlegen"));
     registerField(qsl("createNewDb"), rbNew);
     QRadioButton* rbOpen = new QRadioButton(qsl("Eine existierende Datenbank öffnen"));
-    QVBoxLayout* l =new QVBoxLayout();
-    l->addWidget(rbNew);
-    l->addWidget(rbOpen);
-    setLayout(l);
+    QVBoxLayout* lv =new QVBoxLayout();
+    lv->addWidget(subTitleLabel);
+    lv->addWidget(rbNew);
+    lv->addWidget(rbOpen);
+
+    setLayout(lv);
 }
 
 //void wizOpenOrNewDatabase::initializePage()
@@ -60,7 +63,8 @@ QString defaultDKDB_Filename() {
 wpNewDb::wpNewDb(QWidget* p) : QWizardPage(p)
 {   LOG_CALL;
     setTitle(qsl("Angaben zur neuen Datenbank"));
-    setSubTitle(qsl("Wähle ein Verzeichnis aus und gib den Namen für die neue Datenbank an"));
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("Wähle ein Verzeichnis aus und gib den Namen für die neue Datenbank an"));
 
     QLabel* lVerzeichnis =new QLabel(qsl("&Verzeichnis"));
     QLineEdit* verzeichnis =new QLineEdit();
@@ -79,6 +83,7 @@ wpNewDb::wpNewDb(QWidget* p) : QWizardPage(p)
     layoutFilename->addWidget(dateiname);
 
     QVBoxLayout* l =new QVBoxLayout();
+    l->addWidget(subTitleLabel);
     l->addLayout(layoutFolder);
     l->addLayout(layoutFilename);
     setLayout(l);
@@ -147,7 +152,8 @@ int wpNewDb::nextId() const
 wpExistingDb::wpExistingDb(QWidget* p) : QWizardPage(p)
 {
     setTitle(qsl("DK Datenbank auswählen"));
-    setSubTitle(qsl("Wähle eine existierende DK Datenbank (*.dkdb) aus"));
+    subTitleLabel->setWordWrap(true);
+    subTitleLabel->setText(qsl("Wähle eine existierende DK Datenbank (*.dkdb) aus"));
     QLabel* lAuswahl =new QLabel(qsl("&Ausgewählte Datei"));
     QLineEdit* leFullfile =new QLineEdit();
     leFullfile->setReadOnly(true);
@@ -156,7 +162,10 @@ wpExistingDb::wpExistingDb(QWidget* p) : QWizardPage(p)
     QHBoxLayout* hbl =new QHBoxLayout();
     hbl->addWidget(lAuswahl);
     hbl->addWidget(leFullfile);
-    setLayout(hbl);
+    QVBoxLayout *lv = new QVBoxLayout();
+    lv->addWidget(subTitleLabel);
+    lv->addLayout(hbl);
+    setLayout(lv);
 }
 
 void wpExistingDb::initializePage()

--- a/DKV2/wizopenornewdatabase.h
+++ b/DKV2/wizopenornewdatabase.h
@@ -2,7 +2,10 @@
 #define WIZOPENORNEWDATABASE_H
 
 #include <QWizard>
+#include <QObject>
 #include <QRadioButton>
+#include <QLabel>
+#include <QString>
 
 enum { NewOrOpen, selectNewFile, selectExistingFile};
 
@@ -15,10 +18,11 @@ struct wpOpenOrNew : public QWizardPage
 //    bool validatePage() override;
 
 private:
-    Q_OBJECT
+    Q_OBJECT;
     bool init =true;
     QRadioButton* rbNew =nullptr;
     QRadioButton* rbExisting =nullptr;
+    QLabel *subTitleLabel = new QLabel();
 };
 
 struct wpNewDb : public QWizardPage
@@ -29,7 +33,9 @@ struct wpNewDb : public QWizardPage
     void setVisible(bool v) override;
     int nextId() const override;
 private:
-    Q_OBJECT
+    Q_OBJECT;
+    QLabel *subTitleLabel = new QLabel();
+
 private slots:
     void browseButtonClicked();
 };
@@ -42,7 +48,8 @@ struct wpExistingDb : public QWizardPage
     void setVisible(bool v) override;
     int nextId() const override;
 private:
-    Q_OBJECT
+    Q_OBJECT;
+    QLabel *subTitleLabel = new QLabel();
 private slots:
     void browseButtonClicked();
 };

--- a/DKV2/wizterminatecontract.cpp
+++ b/DKV2/wizterminatecontract.cpp
@@ -10,11 +10,14 @@
 wpTerminateContract_DatePage::wpTerminateContract_DatePage(QWidget* p) : QWizardPage(p)
 {
     setTitle(qsl("Vertrag beenden"));
-    QDateEdit* de = new QDateEdit;
+    subTitleLabel->setWordWrap(true);
+
+    QDateEdit *de = new QDateEdit;
     de->setDisplayFormat(qsl("dd.MM.yyyy"));
     registerField(qsl("date"), de);
     de->setToolTip(qsl("Rückerstattungsdatum"));
     QVBoxLayout* layout = new QVBoxLayout;
+    layout->addWidget(subTitleLabel);
     layout->addWidget(de);
     setLayout(layout);
 }
@@ -27,7 +30,7 @@ void wpTerminateContract_DatePage::initializePage()
     QString subt {qsl("Mit dieser Dialogfolge kannst Du den Vertrag <p><b>%1</b> von <b>%2</b><p> beenden.<p>"
                 "Gib das Datum an, zu dem der Vertrag ausgezahlt wird. "
                 "Bis zu diesem Datum werden die Zinsen berechnet. ")};
-    setSubTitle(subt.arg(Kennung, creditorName));
+    subTitleLabel->setText(subt.arg(Kennung, creditorName));
     setField(qsl("date"), wiz->cont.plannedEndDate());
 }
 
@@ -45,13 +48,15 @@ bool wpTerminateContract_DatePage::validatePage()
 wpTerminateContract_ConfirmationPage::wpTerminateContract_ConfirmationPage(QWidget* p) : QWizardPage(p)
 {
     setTitle(qsl("Vertrag beenden"));
-    QCheckBox* cbPrint = new QCheckBox(qsl("Beleg als CSV Datei speichern"));
+    subTitleLabel->setWordWrap(true);
+    QCheckBox *cbPrint = new QCheckBox(qsl("Beleg als CSV Datei speichern"));
     registerField(qsl("print"), cbPrint);
     cbPrint->setToolTip(qsl("Die Datei wird in dem konfigurierten Ausgabeordner gespeichert"));
     QCheckBox* cbConfirm = new QCheckBox(qsl("Die Engaben sind korrekt"));
     registerField(qsl("confirm"), cbConfirm);
     cbConfirm->setToolTip(qsl("Bestätige, dass die Eingaben richtig sind!"));
     QVBoxLayout* layout = new QVBoxLayout;
+    layout->addWidget(subTitleLabel);
     layout->addWidget(cbPrint);
     layout->addWidget(cbConfirm);
     setLayout(layout);
@@ -71,7 +76,7 @@ void wpTerminateContract_ConfirmationPage::initializePage()
                        "</table>");
     QLocale locale;
     subtitle = subtitle.arg(locale.toCurrencyString(wiz->cont.value()), locale.toCurrencyString(interest), locale.toCurrencyString(finalValue));
-    setSubTitle(subtitle);
+    subTitleLabel->setText(subtitle);
 }
 void wpTerminateContract_ConfirmationPage::onConfirmData_toggled(int)
 {

--- a/DKV2/wizterminatecontract.h
+++ b/DKV2/wizterminatecontract.h
@@ -3,6 +3,7 @@
 
 #include <QWizard>
 #include <QDate>
+#include <QLabel>
 
 #include "contract.h"
 
@@ -12,6 +13,8 @@ struct wpTerminateContract_DatePage : public QWizardPage
     void initializePage() override;
     bool validatePage() override;
     Q_OBJECT;
+private:
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 class wpTerminateContract_ConfirmationPage : public QWizardPage
@@ -23,6 +26,9 @@ public:
     bool isComplete() const override;
 public slots:
     void onConfirmData_toggled(int);
+
+private:
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 struct wizTerminateContract : public QWizard
@@ -30,6 +36,9 @@ struct wizTerminateContract : public QWizard
     wizTerminateContract(QWidget* p, contract& c);
     contract& cont;
     Q_OBJECT;
+
+private:
+    QLabel *subTitleLabel = new QLabel(qsl("Keine Daten!"));
 };
 
 #endif // WIZTERMINATECONTRACT_H


### PR DESCRIPTION
Solves the problem that the creditor and contract info is not shown in the respective confirmation pages under linux.
Has to be tested with MSWin and MacOS.
Output path of PDF output is corrected.