### PR TITLE
Try to fix linux build, add Dockerfile for local builds

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,4 @@
+## Building on linux
+
+The easiest way to build on linux uses Docker to install Qt and required libraries.
+Run `./dist_linux_docker.sh` to build a Docker image from the `Dockerfile` included in the repo and then use this Docker image to actually build DKV2. This will result in a `DKV2-[version].AppImage` in the `build-dist-linux` folder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:16.04
+# FROM mhitza/linuxdeployqt:5.11.3
+
+# Install basics
+RUN apt update && \
+      apt install --assume-yes wget fuse binutils libglib2.0-0 software-properties-common git
+
+# Install python and aqtinstall
+RUN add-apt-repository ppa:deadsnakes/ppa && apt update && \
+      apt install --assume-yes python3.7 python3-pip && \
+      update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 && \
+      python3 -m pip install --upgrade pip
+RUN pip3 install "aqtinstall==1.1.5"
+
+# Install libraries
+RUN apt-get update && \
+      apt-get install -y icnsutils libxcb-xfixes0 libxcb-icccm4-dev libxcb-icccm4 freetds-dev libsybdb5 libsybdb5 libxcb-image0 libxcb-image0-dev libgl1-mesa-dev libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-keysyms1-dev libxcb-render-util0 libxcb-xinerama0 libzstd-dev libcurl4-openssl-dev
+
+# Install QT
+ARG QT_VERSION=5.15.2
+ARG QT_MODULES="qtgui qtwidgets qtsql qtcharts qtprintsupport qtstyleplugins"
+WORKDIR /tmp
+RUN aqt install $QT_VERSION linux desktop \
+      --modules $QT_MODULES \
+      -b https://mirrors.ocf.berkeley.edu/qt \
+    && mkdir /qt \
+    && cp -R ./$QT_VERSION/gcc_64/* /qt \
+    && rm -rf ./$QT_VERSION
+
+# Install linuxdeployqt
+RUN wget https://github.com/probonopd/linuxdeployqt/releases/download/7/linuxdeployqt-7-x86_64.AppImage \
+      --quiet --output-document=/usr/bin/linuxdeployqt && \
+    chmod +x /usr/bin/linuxdeployqt
+    
+# Install more things
+RUN apt-get install -y libfontconfig1 libegl1-mesa libcups2 libodbc1 libpq5 libgtk-3-0
+
+# Set QTDIR variable
+ENV QTDIR /qt
+ENV QML_IMPORT_PATH="/qt/qml:/app/DKV2"
+ENV QML2_IMPORT_PATH="/qt/qml:/app/DKV2"
+# Run build script
+WORKDIR /app
+CMD /app/dist_linux.sh

--- a/dist_linux.sh
+++ b/dist_linux.sh
@@ -19,12 +19,25 @@ if [ -z ${QTDIR+x} ]; then
 	echo "  export QTDIR=~/Qt/5.15.0/gcc_64"
 	exit 1
 fi
+
 QMAKE=${QTDIR}/bin/qmake
 MAKE=make
-# LINUXDEPLOYQT="linuxdeployqt"
-LINUXDEPLOYQT=`pwd`/linuxdeployqt-continuous-x86_64.AppImage
+
 GIT_VERSION=`git rev-parse --short HEAD`
 VERSION=`git describe --tags 2> /dev/null || echo $GIT_VERSION`
+
+LINUXDEPLOYQT="linuxdeployqt"
+if ! command -v $LINUXDEPLOYQT &> /dev/null; then
+	LINUXDEPLOYQT=`pwd`/linuxdeployqt-continuous-x86_64.AppImage
+fi
+
+echo "Building with QTDIR: \`${QTDIR}\`"
+
+##### download linuxdeployqt
+
+if [ ! -f $LINUXDEPLOYQT ]; then
+	curl -o "$LINUXDEPLOYQT" "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+fi
 
 ##### build #####
 
@@ -42,19 +55,23 @@ ${MAKE} -j6
 mkdir -p app
 pushd app
 cp ${SOURCEDIR}/res/logo256.png dkv2.png
-cp ${SOURCEDIR}/res/DKV2.desktop ./
-mv ${BUILDDIR}/DKV2 ./
+cp ${SOURCEDIR}/res/DKV2.desktop .
+mv ${BUILDDIR}/DKV2 .
 popd
 
 unset LD_LIBRARY_PATH # Remove too old Qt from the search path
 # LINUXDEPLOYQT_OPTS=-unsupported-allow-new-glibc
-PATH=${QTDIR}/bin:${PATH} ${LINUXDEPLOYQT} app/DKV2 -bundle-non-qt-libs ${LINUXDEPLOYQT_OPTS}
-PATH=${QTDIR}/bin:${PATH} ${LINUXDEPLOYQT} app/DKV2 -appimage ${LINUXDEPLOYQT_OPTS}
+# PATH=${QTDIR}/bin:${PATH} ${LINUXDEPLOYQT} app/DKV2 -bundle-non-qt-libs ${LINUXDEPLOYQT_OPTS}
+EXTRA_PLUGINS="platforms/libqxcb.so,platformthemes/libqgtk3.so,styles/libqgtk3style.so"
+PATH=${QTDIR}/bin:${PATH} ${LINUXDEPLOYQT} app/DKV2 \
+	-extra-plugins=${EXTRA_PLUGINS} \
+	-appimage ${LINUXDEPLOYQT_OPTS}
 
 APPIMAGE_GIT_FILENAME="DKV2-${GIT_VERSION}-x86_64.AppImage"
 APPIMAGE_RES_FILENAME="DKV2-${VERSION}-x86_64.AppImage"
-ARTIFCACT_FILENAME="DKV2-${VERSION}-x86_64.tar.gz"
+ARTIFCACT_FILENAME="DKV2-${VERSION}-linux-x86_64.tar.gz"
 
 mv ${APPIMAGE_GIT_FILENAME} ${APPIMAGE_RES_FILENAME} 2>/dev/null | true
 tar -czf ${ARTIFCACT_FILENAME} ${APPIMAGE_RES_FILENAME}
+chown -R $LOCAL_USER:$LOCAL_GROUP `pwd`
 echo "Created ${BUILDDIR}/${ARTIFCACT_FILENAME}"

--- a/dist_linux_docker.sh
+++ b/dist_linux_docker.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+docker build -t dkv2-build .
+docker run \
+	--name dkv2-build \
+	--privileged \
+	--cap-add SYS_ADMIN \
+	--device /dev/fuse \
+	-v "$(pwd)":/app \
+	-e LOCAL_USER=$(id -u $USER) \
+	-e LOCAL_GROUP=$(id -g $USER) \
+	--rm -ti \
+	dkv2-build


### PR DESCRIPTION
* Trying to fix issues with libxcb being missing in the final AppImage
* Adding a Dockerfile to do reproducible local builds

Likely we'll want the Github workflow to use the Dockerimage too to have the same environment. This will require pushing the image to Dockerhub and then adapting the Github Action workflow.

Let's first wait if the new build actually fixes the issue we were told about via email.