### PR TITLE
letterformat: reduce top margin for larger logo

### DIFF
--- a/DKV2/filewriter.cpp
+++ b/DKV2/filewriter.cpp
@@ -65,7 +65,7 @@ bool pdfWrite(const QString& templateName, const QString& fileName, const QVaria
     printer.setOutputFormat(QPrinter::PdfFormat);
     QPageLayout pl =printer.pageLayout ();
     double leftB   = cm2Pt(3.); // breiter für Lochung
-    double topB    = cm2Pt(2.);
+    double topB    = cm2Pt(1.); // logo darf in den oberen Rand reichen
     double rightB  = cm2Pt(0.); // logo darf in den Rand reichen
     double bottomB = cm2Pt(2.);
     pl.setPageSize (QPageSize(QPageSize::A4), QMargins(leftB, topB,rightB, bottomB));

--- a/DKV2/res/zinsbrief.css
+++ b/DKV2/res/zinsbrief.css
@@ -16,11 +16,15 @@ table {
 }
 
 .colFirmenname {
-    text-align: center;
+    padding-top: 29px;
     padding-left: 0px;
-    font-size: 14pt;
-    padding-top: 6px;
     padding-bottom: 6px;
+
+}
+
+.divFirmenname {
+    text-align: center;
+    font-size: 14pt;
 
 }
 
@@ -37,12 +41,16 @@ table {
     padding-bottom: 10px;
 }
 
+/*
 .imgLogo {
 
 }
+*/
 
 .colLogo {
+    padding-top: 23px;
     float: right;
+
 }
 
 .GmbHUrl {

--- a/DKV2/res/zinsbrief.html
+++ b/DKV2/res/zinsbrief.html
@@ -7,8 +7,8 @@
 <body>
     <table width=98%>
         <tr>
-            <td width=40%>
-              <div class="colFirmenname"> <b>{{meta.gmbhaddress1}}</b><p></div>
+            <td width=40% class="colFirmenname">
+              <div class="divFirmenname"> <b>{{meta.gmbhaddress1}}</b><p></div>
               <div class="GmbHAnschrift"> {{meta.gmbhstrasse}} | {{meta.gmbhplz}} {{meta.gmbhstadt}}</div>
               <div class="KreditorAdresse" ><br>
                   {{creditor.Vorname}} {{creditor.Nachname}}<p>


### PR DESCRIPTION
Ich habe den topmargin für den Zinsbrief auf 1cm reduziert und (hoffentlich) das css/html so angepasst, dass das Layout erhalten geblieben ist.
Das OM10-Logo ist sonst zu raumgreifend nach unten. Das geht anderen vielleicht ähnlich und es ist natürlich gut, wenn man das ohne Eingriff in den Programm-Code ändern kann.