### PR TITLE
Allow change of column size in contract table view

### DIFF
--- a/DKV2/contractsheadersortingadapter.cpp
+++ b/DKV2/contractsheadersortingadapter.cpp
@@ -81,7 +81,8 @@ qInfo() << "index: " << indexAtCursor;
             header->setSortIndicatorShown(false);
         }
         emit header->sectionClicked(indexAtCursor);
-        m_table->resizeColumnsToContents();
+        // It shouldn't be necessary to resize column (as content didn't change)
+        // m_table->resizeColumnsToContents();
         m_table->resizeRowsToContents();
         return true;
     }


### PR DESCRIPTION
In der Vertragsliste konnte man die Spaltenbreite nicht ändern - bzw. sie wurde immer wieder sofort zurückgeändert.
Das habe ich geändert in contractsheadersortingadapter.cpp. Da beim Sortieren der Inhalt der Spalten nicht geändert wird, sollte das keine unerwünschten Nebeneffekte haben.