### PR TITLE
issue #43 SegFault fixed in MainWindow::updateViews

### DIFF
--- a/DKV2/mainwindow.cpp
+++ b/DKV2/mainwindow.cpp
@@ -319,14 +319,20 @@ void MainWindow::updateViews()
             temp->select();
     }
     if( ui->stackedWidget->currentIndex() == contractsListPageIndex) {
-        if( (temp =qobject_cast<QSqlTableModel*>(ui->contractsTableView->model())))
-            temp->select();
-        if( (temp =qobject_cast<QSqlTableModel*>(ui->bookingsTableView ->model())))
-            temp->select();
+        ContractProxyModel *contractsTableProxy_ptr = qobject_cast<ContractProxyModel *>(ui->contractsTableView->model());
+        QSqlTableModel *bookingsTableModel_ptr = qobject_cast<QSqlTableModel *>(ui->bookingsTableView->model());
+        ContractTableModel *contractsTableModel_ptr = nullptr;
+        if (contractsTableProxy_ptr)
+            contractsTableModel_ptr = qobject_cast<ContractTableModel *>(contractsTableProxy_ptr->sourceModel());
+        if (contractsTableModel_ptr)
+            contractsTableModel_ptr->select();
+        if (bookingsTableModel_ptr)
+            bookingsTableModel_ptr->select();
         ui->contractsTableView->resizeColumnsToContents();
         ui->contractsTableView->resizeRowsToContents();
         ui->bookingsTableView->resizeColumnsToContents();
-        qobject_cast<ContractTableModel*>(ui->contractsTableView->model())->setCol13ExtraData();
+        if (contractsTableModel_ptr)
+            contractsTableModel_ptr->setCol13ExtraData();
     }
     if( ui->stackedWidget->currentIndex() == investmentsPageIndex) {
         prepare_investmentsListView();


### PR DESCRIPTION
It wasn't as simple as I thought. 
The problem was the cast of the abstract model pointers. As the newly introduced QSortFilterProxyModel is not inherited from QSqlTableModel the casting 'went to forest'!
Seems to be fixed now.