### PR TITLE
Issue #62: Handle empty first name of creditor

### DIFF
--- a/DKV2/contract.cpp
+++ b/DKV2/contract.cpp
@@ -172,16 +172,14 @@ double contract::interestBearingValue() const
 
 const booking contract::latestBooking()
 {
-    QSqlRecord rec = executeSingleRecordSql(dkdbstructur[qsl("Buchungen")].Fields(), qsl("VertragsId=") + id_aS(), qsl("rowid DESC LIMIT 1"));
+//dbgTimer timer(qsl("latestBooking"));
+    QString sql {qsl("SELECT id, VertragsId, Datum, BuchungsArt, Betrag FROM Buchungen WHERE VertragsId=%1 ORDER BY rowid DESC LIMIT 1").arg(id_aS())};
+    QSqlRecord rec = executeSingleRecordSql(sql);
     if( 0 == rec.count()) {
         qInfo() << "latestBooking returns empty value";
         return booking();
     }
-    booking latestB;
-    latestB.type   =booking::Type(rec.value(qsl("BuchungsArt")).toInt());
-    latestB.date   =rec.value(qsl("Datum")).toDate();
-    latestB.amount =euroFromCt(rec.value(qsl("Betrag")).toInt());
-    latestB.contractId = id();
+    booking latestB(id(), booking::Type(rec.value(qsl("BuchungsArt")).toInt()), rec.value(qsl("Datum")).toDate(), euroFromCt(rec.value(qsl("Betrag")).toInt()));
     qDebug() << "Latest Booking: " << booking::displayString(latestB.type) << ", " << latestB.date << ", " << latestB.amount << ", cId:" << latestB.contractId;
     return latestB;
 }

--- a/DKV2/contract.h
+++ b/DKV2/contract.h
@@ -163,21 +163,18 @@ struct contract
     // interestBearingValue depends on interestMode
     double interestBearingValue() const;
 
-    const booking& latestBooking();
-    void setLatestBooking( const booking& b) { latestB=b;};
+    const booking latestBooking();
     // write to db
     int saveNewContract();
     bool updateComment(const QString&);
     bool updateTerminationDate(QDate termination, int noticePeriod);
     bool updateInvestment(qlonglong id);
-/* not used?  int validateAndSaveNewContract(QString& meldung); */
+
     // contract activation
     bool bookInitialPayment(const QDate aDate, double amount);
     bool initialBookingReceived() const;
-    QDate initialBookingDate() const;
-    void setInitialBookingDate( const QDate d) {aDate=d; activated=active;}
 
-    bool bookActivateInterest(QDate d);
+    bool bookActivateInterest(const QDate d);
 
     // other booking actions
     QDate nextDateForAnnualSettlement();
@@ -195,7 +192,6 @@ struct contract
 private:
     // data
     TableDataInserter td;
-    booking latestB;
     // helper
     double ZinsesZins(const double zins, const double wert,const QDate von, const QDate bis, const bool thesa =true);
 
@@ -203,9 +199,6 @@ private:
     bool storeTerminationDate(const QDate d) const;
     bool archive();
     void reset() {initContractDefaults();}
-    mutable enum constract_activation_status
-         { uninit =-1, passive =0, active =1 } activated=uninit;
-    mutable QDate aDate = EndOfTheFuckingWorld;
 };
 
 // test helper

--- a/DKV2/creditor.cpp
+++ b/DKV2/creditor.cpp
@@ -38,7 +38,10 @@ bool creditor::operator==(const creditor& c) const
         if( postalCode() not_eq c.postalCode()) break;
         if( city()      not_eq c.city()) break;
         if( comment()   not_eq c.comment()) break;
-        if( email()     not_eq c.email()) break;
+        if (email() not_eq c.email()) break;
+        if( tel()       not_eq c.tel()) break;
+        if (contact() not_eq c.contact()) break;
+        if (account() not_eq c.account()) break;
         if( iban()      not_eq c.iban()) break;
         if( bic()       not_eq c.bic()) break;
         ret = true;
@@ -52,6 +55,9 @@ bool creditor::operator==(const creditor& c) const
         qInfo() << city() << " vs. " << c.city();
         qInfo() << comment() << " vs. " << c.comment();
         qInfo() << email() << " vs. " << c.email();
+        qInfo() << tel() << " vs. " << c.tel();
+        qInfo() << contact() << " vs. " << c.contact();
+        qInfo() << account() << " vs. " << c.account();
         qInfo() << iban() << " vs. " << c.iban();
         qInfo() << bic() << " vs. " << c.bic();
     }
@@ -133,6 +139,9 @@ QVariant creditor::getVariant()
     v["Stadt"] = ti.getValue(fnStadt).toString();
     v["Land"] = ti.getValue(fnLand).toString();
     v["Email"] = ti.getValue(fnEmail).toString();
+    v["Telefon"] = ti.getValue(fnTel).toString();
+    v["Kontakt"] = ti.getValue(fnKontakt).toString();
+    v["Buchungskonto"] = ti.getValue(fnBuchungskonto).toString();
     v["IBAN"] = ti.getValue(fnIBAN).toString();
     v["BIC"] = ti.getValue(fnBIC).toString();
     v["Anmerkung"] = getValue(fnAnmerkung).toString();
@@ -313,6 +322,9 @@ creditor saveRandomCreditor()
     c.setIban(ibans[rand->bounded(ibans.count())]);
     c.setBic(qsl("bic...         ."));
     c.setComment(qsl(""));
+    c.setTel(qsl(""));
+    c.setContact(qsl(""));
+    c.setAccount(qsl(""));
     Q_ASSERT(c.isValid());
     c.save();
     return c;

--- a/DKV2/creditor.cpp
+++ b/DKV2/creditor.cpp
@@ -231,14 +231,14 @@ void fillCreditorsListForLetters(QList<QPair<int,QString>>& entries, int booking
     if( bookingYear == -1)
         sql =         sql =qsl(R"str(
 SELECT id
-  , Nachname || ', ' || Vorname || ' '||  Plz || '-' || Stadt || ' ' || Strasse
+  , IFNULL(Nachname || ', ' || Vorname, Nachname) || ' '||  Plz || '-' || Stadt || ' ' || Strasse
 FROM Kreditoren
 ORDER BY Nachname ASC, Vorname ASC
 )str");
     else
-        sql =qsl(R"str(
+        sql = qsl(R"str(
 SELECT id
-  , Nachname || ', ' || Vorname || ' '||  Plz || '-' || Stadt || ' ' || Strasse
+  , IFNULL(Nachname || ', ' || Vorname, Nachname) || ' '||  Plz || '-' || Stadt || ' ' || Strasse
 FROM Kreditoren
 WHERE id IN (
 SELECT DISTINCT Kreditoren.Id AS kid
@@ -247,7 +247,8 @@ INNER JOIN Vertraege ON Buchungen.VertragsId = Vertraege.id
 INNER JOIN Kreditoren ON Vertraege.KreditorId = Kreditoren.id
 WHERE Buchungen.BuchungsArt = %1 AND SUBSTR(Buchungen.Datum, 1, 4) = '%2')
 ORDER BY Nachname ASC, Vorname ASC
-)str").arg(QString::number((int)booking::Type::annualInterestDeposit), QString::number (bookingYear));
+)str")
+                  .arg(QString::number((int)booking::Type::annualInterestDeposit), QString::number(bookingYear));
 
     qDebug() << sql;
     if( not query.exec(sql)) {

--- a/DKV2/dkdbhelper.cpp
+++ b/DKV2/dkdbhelper.cpp
@@ -403,6 +403,7 @@ fortlaufendeGeldanlagen AS
 
   FROM geldBewegungen
   GROUP BY aId, bDatum
+  ORDER BY aId DESC, bDatum DESC
 )
 SELECT
   aId

--- a/DKV2/dkdbviews.cpp
+++ b/DKV2/dkdbviews.cpp
@@ -310,10 +310,11 @@ QString getView(const QString &vn) {
 
 const QStringList getIndexSql() {
     return {
-        qsl("CREATE INDEX 'Buchungen-BArt' ON 'Buchungen' ( 'BuchungsArt' )"),
-        qsl("CREATE INDEX 'Buchungen-vid-bdatum' ON 'Buchungen' ('VertragsId', 'Datum' )"),
-        qsl("CREATE INDEX 'Vertraege-aId' ON 'Vertraege' ( 'AnlagenId' )"),
-        qsl("CREATE INDEX 'Vertraege-Datum' ON 'Vertraege' ('Vertragsdatum' )"),
+        qsl("CREATE INDEX 'Buchungen-vId'        ON 'Buchungen' ( 'VertragsId')"),
+        qsl("CREATE INDEX 'Buchungen-vid-bdatum' ON 'Buchungen' ( 'VertragsId', 'Datum' )"),
+        qsl("CREATE INDEX 'Buchungen-BArt'       ON 'Buchungen' ( 'BuchungsArt' )"),
+        qsl("CREATE INDEX 'Vertraege-aId'    ON 'Vertraege'   ( 'AnlagenId' )"),
+        qsl("CREATE INDEX 'Vertraege-Datum'  ON 'Vertraege'   ('Vertragsdatum' )"),
         qsl("CREATE INDEX 'Geldanlagen-Ende' ON 'Geldanlagen' ( 'Ende' )")
     };
 }

--- a/DKV2/dkdbviews.cpp
+++ b/DKV2/dkdbviews.cpp
@@ -394,6 +394,9 @@ SELECT
   Kreditoren.Plz        AS Plz,
   Kreditoren.Stadt      AS Stadt,
   Kreditoren.Email      AS Email,
+  Kreditoren.Telefon    AS Telefon,
+  Kreditoren.Kontakt    AS Kontakt
+  Kreditoren.Buchungskonto AS Buchungskonto,
   Kreditoren.IBAN       AS Iban,
   Kreditoren.BIC        AS Bic
 FROM Vertraege

--- a/DKV2/dkdbviews.cpp
+++ b/DKV2/dkdbviews.cpp
@@ -10,7 +10,7 @@ SELECT
   V.id AS VertragsId
   ,K.id AS KreditorId
   ,V.AnlagenId AS AnlagenId
-  ,K.Nachname || ', ' || K.Vorname          AS KreditorIn
+  ,IFNULL(K.Nachname || ', ' || K.Vorname, K.Nachname) AS KreditorIn
   ,V.Kennung AS Vertragskennung
   ,V.Anmerkung AS Anmerkung
   ,V.Vertragsdatum     AS Vertragsdatum
@@ -75,12 +75,12 @@ LEFT JOIN
 )str")};
 
 const QString vnExContractView {qsl("vVertraege_geloescht")};
-const QString sqlExContractView {qsl(
-R"str(
+const QString sqlExContractView{qsl(
+    R"str(
 SELECT
   V.id AS VertragsId
   , K.id AS KreditorId
-  , K.Nachname || ', ' || K.Vorname AS KreditorIn
+  , IFNULL(K.Nachname || ', ' || K.Vorname, K.Nachname) AS KreditorIn
   , V.Kennung AS Vertragskennung
   , strftime('%d.%m.%Y',Aktivierungsdatum) AS Aktivierung
   , strftime('%d.%m.%Y', Vertragsende) AS Vertragsende
@@ -146,8 +146,7 @@ LEFT JOIN ( SELECT
             WHERE B.BuchungsArt = 1 OR B.BuchungsArt = 2 OR B.BuchungsArt = 8
             GROUP BY B.VertragsId  )
 ON V.id = vid_mit_Zinsen
-)str"
-)};
+)str")};
 
 const QString vnInvestmentsView {qsl("vInvestmentsOverview")};
 const QString sqlInvestmentsView {qsl(
@@ -375,8 +374,8 @@ FROM
 )str").arg(sqlNextAnnualSettlement_firstAS, sqlNextAnnualSettlement_nextAS)};
 
 // Listenausdruck createCsvActiveContracts
-const QString sqlContractsActiveDetailsView{ qsl(
-R"str(
+const QString sqlContractsActiveDetailsView{qsl(
+    R"str(
 SELECT
   Vertraege.id          AS id,
   Vertraege.Kennung     AS Vertragskennung,
@@ -386,7 +385,7 @@ SELECT
   Vertraege.Kfrist      AS Kuendigungsfrist,
   Vertraege.LaufzeitEnde  AS Vertragsende,
   Vertraege.thesaurierend AS thesa,
-  Kreditoren.Nachname || ', ' || Kreditoren.Vorname AS Kreditorin,
+  IFNULL(K.Nachname || ', ' || K.Vorname, K.Nachname) AS KreditorIn,
   Kreditoren.id         AS KreditorId,
   Kreditoren.Nachname   AS Nachname,
   Kreditoren.Vorname    AS Vorname,
@@ -403,8 +402,7 @@ FROM Vertraege
     INNER JOIN Buchungen  ON Buchungen.VertragsId = Vertraege.id
     INNER JOIN Kreditoren ON Kreditoren.id = Vertraege.KreditorId
 GROUP BY Vertraege.id
-)str"
-)};
+)str")};
 // uebersicht contract use and other uses
 const QString sqlContractsActiveView { qsl(
 R"str(

--- a/DKV2/helper.h
+++ b/DKV2/helper.h
@@ -26,8 +26,8 @@ class dbgTimer
 {
     QElapsedTimer t;
     QString fname;
-    int labcount =0;
-    int lastLab =0;
+    qint64 labcount =0;
+    qint64 lastLab =0;
 public:
     dbgTimer() {t.start();}
     dbgTimer(const dbgTimer&) = delete;
@@ -35,11 +35,11 @@ public:
     ~dbgTimer() {qInfo().noquote() << Qt::endl << (fname.isEmpty() ? qsl("") : fname+ qsl(" end") )
                                    << Qt::endl << qsl("Elapsed time: ")<< t.elapsed() << "ms" << Qt::endl;}
     void lab(const QString& msg =QString()) {
-        int now =t.elapsed();
-        qInfo().noquote() << (fname.isEmpty() ? qsl("") : fname) <<  qsl(" Lab time ")
+        qint64 now =t.elapsed();
+        qInfo().noquote() << (fname.isEmpty() ? qsl("") : fname) <<  qsl(" Lab# ")
                           << (msg.isEmpty() ? QString::number(labcount++) : msg)
-                          << now
-                          << "ms (delta: " << now-lastLab << ")";
+                          << ":" << (now-lastLab)
+                          << "ms (overall: " << now << ")";
         lastLab =now;
     }
 };

--- a/DKV2/mainwindow.cpp
+++ b/DKV2/mainwindow.cpp
@@ -975,7 +975,8 @@ void MainWindow::on_action_menu_debug_show_log_triggered()
 
 void MainWindow::on_actionDatenbank_Views_schreiben_triggered()
 {
-    insertDKDB_Views(QSqlDatabase::database());
+    insertDKDB_Views ();
+    insertDKDB_Indices ();
 }
 // about
 void MainWindow::on_action_about_DKV2_triggered()

--- a/DKV2/mainwindow.cpp
+++ b/DKV2/mainwindow.cpp
@@ -210,6 +210,10 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->action_menu_debug_create_sample_data->setVisible(false);
 #endif
 
+#ifdef Q_OS_MAC
+    ui->action_menu_contracts_statistics_view->setText(QStringLiteral("Uebe&rsichten"));
+#endif
+
     ui->statusBar->addPermanentWidget(ui->statusLabel);
     setCentralWidget(ui->stackedWidget);
 

--- a/DKV2/mainwindow_contractlist.cpp
+++ b/DKV2/mainwindow_contractlist.cpp
@@ -171,15 +171,20 @@ void MainWindow::prepare_valid_contracts_list_view()
     tv->setItemDelegateForColumn(cp_InterestMode, new interestModeFormatter(tv));
 
     QBitArray ba =toQBitArray(getMetaInfo (qsl("VertraegeSpalten"), qsl("000111111111111")));
-    if( ba.size () >= cp_colCount) {
-        ba[0] = ba[1] = ba[2] =false;
-        for(int i=0; i<int(colmn_Pos::cp_colCount); i++) {
-            if( ba[i])
-                tv->showColumn (i);
-            else
-                tv->hideColumn (i);
-        }
+    /* Hide the unwanted id columns */
+    ba[cp_vid] = ba[cp_Creditor_id] = ba[cp_Investment_id] = false;
+    /* Force minimum length of QBitArray */
+    int oldSize = ba.size();
+    ba.resize(cp_colCount);
+    ba.fill(true, oldSize, cp_colCount + 1);
+
+    for(int i=0; i<int(colmn_Pos::cp_colCount); i++) {
+        if( ba[i])
+            tv->showColumn (i);
+        else
+            tv->hideColumn (i);
     }
+    
 
     tv->resizeColumnsToContents();
     tv->resizeRowsToContents();
@@ -231,10 +236,16 @@ void MainWindow::prepare_deleted_contracts_list_view()
     contractsTV->hideColumn(cp_d_Creditor_id);
 
     QBitArray ba =toQBitArray (getMetaInfo (qsl("geloeschteVertraegeSpalten")));
-    if( ba.size () >= cp_d_colCount) {
-        ba[0] = ba[1] = ba[2] =false;
-        for(int i=0; i<int(cp_d_colCount); i++) {
-            if( ba[i])
+    /* force hiding the unwanted ids */
+    ba[cp_d_vid] = ba[cp_d_Creditor_id] = false;
+    /* make sure that array is long enough to hold all columns */
+    int oldSize = ba.size();
+    ba.resize(cp_d_colCount);
+    ba.fill(true, oldSize, cp_d_colCount + 1);
+    for (int i = 0; i < int(cp_d_colCount); i++)
+    {
+        if( ba.size () > i ) {
+            if( ba.size() < i || ba[i])
                 contractsTV->showColumn (i);
             else
                 contractsTV->hideColumn (i);
@@ -288,6 +299,10 @@ void MainWindow::on_btnVertragsSpalten_clicked()
         initMetaInfo +="1";
     }
     QBitArray ba =toQBitArray(getMetaInfo (storageName, initMetaInfo));
+    /* force right length of QBitArray */
+    int oldSize = ba.size();
+    ba.resize(colCount);
+    ba.fill(true, oldSize, colCount + 1);
 
     dlgDisplayColumns dlg(colInfo, ba, getMainWindow ());
     QFont f =dlg.font(); f.setPointSize(10); dlg.setFont(f);

--- a/DKV2/mainwindow_creditorlist.cpp
+++ b/DKV2/mainwindow_creditorlist.cpp
@@ -24,7 +24,7 @@ enum colPosCreditors {
     col_id =0,
     col_Vorname, col_Nachname,
     col_Strasse, col_Plz, col_Stadt, col_Land,
-    col_Email, col_Tel,
+    col_Tel, col_Email, 
     col_Anmerkung, col_APartner, col_BKonto,
     col_IBAN, col_BIC,
     col_Zeitstempel,
@@ -39,8 +39,8 @@ const QVector<tableViewColTexts> columnTextsCreditors {
     /*col_Plz,       */ {qsl("PLZ"),      qsl("Postleitzahl")},
     /*col_Stadt,     */ {qsl("Stadt"),    qsl("")},
     /*col_Land,      */ {qsl("Land"),     qsl("")},
-    /*col_Email      */ {qsl("E-Mail"),   qsl("E-Mail Adresse zum Zusenden von Vertragsinformation")},
     /*col_Tel,       */ {qsl("Telefon Nr."), qsl("Telefonnummer für schnellen Kontakt")},
+    /*col_Email      */ {qsl("E-Mail"),   qsl("E-Mail Adresse zum Zusenden von Vertragsinformation")},
     /*col_Anmerkung, */ {qsl("Anmerkung"), qsl("Allgemeine Anmerkung")},
     /*col_APartner,  */ {qsl("Ansprechp."), qsl("Ansprechpartner im Projekt")},
     /*col_BKonto,    */ {qsl("Buch.Konto"), qsl("Buchungskonto oder ähnliche Info.")},
@@ -63,12 +63,17 @@ void MainWindow::prepare_CreditorsListPage()
     ui->CreditorsTableView->setModel(model);
 
     QBitArray ba =toQBitArray (getMetaInfo (creditorTableColumnVisibilityStatus, creditorTableColumnVisibilityDefault));
-    if( ba.size() >= col_count) {
-        ba[0] =ba[14] =0;
-        for( int i=0; i<int(colPosCreditors::col_count); i++) {
-            if( ba[i]) ui->CreditorsTableView->showColumn (i);
-            else       ui->CreditorsTableView->hideColumn (i);
-        }
+    /* Force appropriate length of QBitArray */
+    int oldSize = ba.size();
+    ba.resize(col_count);
+    ba.fill(true, oldSize, col_count + 1);
+    /* Hide unwanted columns */
+    ba[col_id] = ba[col_Zeitstempel] = 0;
+
+    for (int i = 0; i < int(colPosCreditors::col_count); i++)
+    {
+        if( ba[i]) ui->CreditorsTableView->showColumn (i);
+        else       ui->CreditorsTableView->hideColumn (i);
     }
 
     ui->CreditorsTableView->setEditTriggers(QTableView::NoEditTriggers);
@@ -164,6 +169,10 @@ void MainWindow::on_actionNeu_triggered()
 void MainWindow::on_pbCreditorsColumnsOnOff_clicked()
 {
     QBitArray ba =toQBitArray (getMetaInfo(creditorTableColumnVisibilityStatus, creditorTableColumnVisibilityDefault));
+    int oldSize = ba.size();
+    ba.resize(col_count);
+    ba.fill(true, oldSize, col_count + 1);
+
     QVector <QPair<int, QString>> colInfo;
     for(int i=0; i<int(colPosCreditors::col_count); i++) {
         colInfo.push_back (QPair<int, QString>(i, columnTextsCreditors[i].header));

--- a/DKV2/transaktionen.cpp
+++ b/DKV2/transaktionen.cpp
@@ -247,8 +247,9 @@ void bookInitialPaymentReceived(contract *v)
 void activateInterest(contract *v)
 {
     LOG_CALL;
-    Q_ASSERT(v->latestBooking().type != booking::Type::non);
-    QDate earlierstActivation = v->latestBooking().date.addDays(1);
+    booking lastB =v->latestBooking ();
+    Q_ASSERT(lastB.type != booking::Type::non);
+    QDate earlierstActivation = lastB.date.addDays(1);
     dlgAskDate dlg(getMainWindow());
     dlg.setDate(earlierstActivation);
     dlg.setHeader(qsl("Aktivierung der Zinszahlung"));
@@ -329,10 +330,10 @@ void annualSettlement()
     QVector<booking> asBookings;
     for (const auto &id : qAsConst(ids)) {
         contract c(id.toLongLong());
-        QDate startDate = c.latestBooking().date;
+        QDate startDate = c.latestBooking ().date;
         if (0 not_eq c.annualSettlement(yearOfSettlement)) {
             changedContracts.push_back(c);
-            asBookings.push_back(c.latestBooking());
+            asBookings.push_back(c.latestBooking ());
             startOfInterrestCalculation.push_back(startDate);
         }
     }

--- a/DKV2/transaktionen.cpp
+++ b/DKV2/transaktionen.cpp
@@ -154,6 +154,8 @@ void editCreditor(qlonglong creditorId)
     wiz.setField(pnPcode, cred.postalCode());
     wiz.setField(pnCity, cred.city());
     wiz.setField(pnEMail, cred.email());
+    wiz.setField(pnPhone, cred.tel());
+    wiz.setField(pnContact, cred.contact());
     wiz.setField(pnComment, cred.comment());
     wiz.setField(pnIban, cred.iban());
     wiz.setField(pnBic, cred.bic());

--- a/DKV2/transaktionen.cpp
+++ b/DKV2/transaktionen.cpp
@@ -509,7 +509,7 @@ void cancelContract(contract &c)
     LOG_CALL;
     wizCancelContract wiz(getMainWindow());
     wiz.c = c;
-    wiz.creditorName = executeSingleValueSql(qsl("Vorname || ' ' || Nachname"), qsl("Kreditoren"), qsl("id=") + QString::number(c.creditorId())).toString();
+    wiz.creditorName = executeSingleValueSql(qsl("IFNULL(Vorname || ' ', '') || Nachname"), qsl("Kreditoren"), qsl("id=") + QString::number(c.creditorId())).toString();
     wiz.contractualEnd = QDate::currentDate().addMonths(c.noticePeriod());
     wiz.exec();
     if (not wiz.field(qsl("confirmed")).toBool()) {

--- a/DKV2/transaktionen.cpp
+++ b/DKV2/transaktionen.cpp
@@ -159,6 +159,7 @@ void editCreditor(qlonglong creditorId)
     wiz.setField(pnComment, cred.comment());
     wiz.setField(pnIban, cred.iban());
     wiz.setField(pnBic, cred.bic());
+    wiz.setField(pnAccount, cred.account());
     wiz.selectCreateContract = false;
     //wiz.setField(pnConfirmContract, false);
     wiz.creditorId = creditorId;

--- a/DKV2/wiznew.cpp
+++ b/DKV2/wiznew.cpp
@@ -102,6 +102,7 @@ bool wpNewOrExisting::validatePage()
         setField(pnComment, c.comment());
         setField(pnIban, c.iban());
         setField(pnBic, c.bic());
+        setField(pnAccount, c.account());
         qInfo() << "User selected user Id " << wiz->creditorId;
     }
     return true;
@@ -305,22 +306,31 @@ int wpEmail::nextId() const
 */
 const QString pnIban{qsl("iban")};
 const QString pnBic{qsl("bic")};
+const QString pnAccount{qsl("account")};
+
 wpBankAccount::wpBankAccount(QWidget *p) : QWizardPage(p)
 {
     LOG_CALL;
     setTitle(qsl("Bankdaten"));
     subTitleLabel->setWordWrap(true);
-    subTitleLabel->setText(qsl("Gib die Bankdaten der neuen Kreditor*in ein.<p>"));
+    subTitleLabel->setText(qsl("Gib die Bank- und Buchhaltungsdaten der neuen Kreditor*in ein.<p>"));
+
     QLabel *l1 = new QLabel(qsl("IBAN"));
     QLineEdit *leIban = new QLineEdit;
     leIban->setToolTip(qsl("Es muss eine gültige IBAN eingegeben werden "
                            "(s. https://de.wikipedia.org/wiki/Internationale_Bankkontonummer)."));
     l1->setBuddy(leIban);
     registerField(pnIban, leIban);
+
     QLabel *l2 = new QLabel(qsl("BIC <small>(optional)</small>"));
     QLineEdit *leBic = new QLineEdit;
     l2->setBuddy(leBic);
     registerField(pnBic, leBic);
+
+    QLabel *l3 = new QLabel(qsl("Buchh.-Konto"));
+    QLineEdit *leAccount = new QLineEdit;
+    l3->setBuddy(leAccount);
+    registerField(pnAccount, leAccount);
 
     QGridLayout *g = new QGridLayout;
     g->addWidget(subTitleLabel);
@@ -328,6 +338,8 @@ wpBankAccount::wpBankAccount(QWidget *p) : QWizardPage(p)
     g->addWidget(leIban);
     g->addWidget(l2);
     g->addWidget(leBic);
+    g->addWidget(l3);
+    g->addWidget(leAccount);
     setLayout(g);
 }
 bool wpBankAccount::validatePage()
@@ -347,6 +359,7 @@ bool wpBankAccount::validatePage()
     }
     setField(pnIban, iban);
     setField(pnBic, field(pnBic).toString().trimmed());
+    setField(pnAccount, field(pnAccount).toString().trimmed());
     return true;
 }
 int wpBankAccount::nextId() const
@@ -392,7 +405,9 @@ void wpConfirmCreditor::initializePage()
                                 "<tr><td>Telefon:</td><td>%6<br></td></tr>"
                                 "<tr><td>Kontakt:</td><td>%7<br></td></tr>"
                                 "<tr><td>Kommentar:</td><td><small>%8<small></td></tr>"
-                                "<tr><td>Bankdaten:</td><td><table><tr><td>IBAN:</td><td>%9</td></tr><tr><td>BIC:</td><td>%10<td></tr></table></td></tr></table>")};
+                                "<tr><td>Bankdaten:</td><td><table><tr><td>IBAN:</td><td>%9</td></tr><tr><td>BIC:</td><td>%10<td></tr></table></td></tr>"
+                                "<tr><td>Buchh.-Konto:</td><td>%11</td></tr>"
+                                "</table>")};
     QString firstn = field(pnFName).toString().isEmpty() ? qsl("(kein Vorname)") : field(pnFName).toString();
     QString lastn = field(pnLName).toString().isEmpty() ? qsl("(kein Nachname)") : field(pnLName).toString();
     QString street = field(pnStreet).toString().isEmpty() ? qsl("(keine Strasse)") : field(pnStreet).toString();
@@ -409,9 +424,9 @@ void wpConfirmCreditor::initializePage()
     QString comment = field(pnComment).toString().isEmpty() ? qsl("(keine Anmerkung)") : field(pnComment).toString();
     QString iban = field(pnIban).toString().isEmpty() ? qsl("(keine IBAN)") : field(pnIban).toString();
     QString bic = field(pnBic).toString().isEmpty() ? qsl("(keine BIC)") : field(pnBic).toString();
-
+    QString account = field(pnAccount).toString().isEmpty() ? qsl("(kein Buchh.-Konto)") : field(pnAccount).toString();
     subTitleLabel->setText(creditorSummary.arg(firstn, lastn, street, xxx,
-                                                 email, phone, contact, comment, iban, bic));
+                                                 email, phone, contact, comment, iban, bic, account));
     wizNew *wiz = qobject_cast<wizNew *>(wizard());
     if (wiz->selectCreateContract)
         cbCreateContract->setChecked(true);
@@ -436,6 +451,7 @@ bool wpConfirmCreditor::validatePage()
     wiz->c_tor.setComment(wiz->field(pnComment).toString());
     wiz->c_tor.setIban(wiz->field(pnIban).toString());
     wiz->c_tor.setBic(wiz->field(pnBic).toString());
+    wiz->c_tor.setAccount(wiz->field(pnAccount).toString());
 
     return true;
 }
@@ -528,6 +544,7 @@ void wpLableAndAmount::cleanupPage()
     setField(pnComment, QString());
     setField(pnIban, QString());
     setField(pnBic, QString());
+    setField(pnAccount, QString());
 }
 bool wpLableAndAmount::validatePage()
 {

--- a/DKV2/wiznew.cpp
+++ b/DKV2/wiznew.cpp
@@ -401,12 +401,12 @@ void wpConfirmCreditor::initializePage()
     QString creditorSummary{qsl("<table><tr><td>Name:</td><td><b>%1 %2</b><br></td></tr>"
                                 "<tr><td>Straße:</td><td>%3</td></tr>"
                                 "<tr><td>Plz/Ort:</td><td>%4</td></tr>"
-                                "<tr><td>E-Mail:</td><td>%5<br></td></tr>"
-                                "<tr><td>Telefon:</td><td>%6<br></td></tr>"
+                                "<tr><td>E-Mail:</td><td>%5</td></tr>"
+                                "<tr><td>Telefon:</td><td>%6</td></tr>"
                                 "<tr><td>Kontakt:</td><td>%7<br></td></tr>"
                                 "<tr><td>Kommentar:</td><td><small>%8<small></td></tr>"
                                 "<tr><td>Bankdaten:</td><td><table><tr><td>IBAN:</td><td>%9</td></tr><tr><td>BIC:</td><td>%10<td></tr></table></td></tr>"
-                                "<tr><td>Buchh.-Konto:</td><td>%11</td></tr>"
+                                "<tr><td>Buchh.-Konto:</td><td>%11<br></td></tr>"
                                 "</table>")};
     QString firstn = field(pnFName).toString().isEmpty() ? qsl("(kein Vorname)") : field(pnFName).toString();
     QString lastn = field(pnLName).toString().isEmpty() ? qsl("(kein Nachname)") : field(pnLName).toString();

--- a/DKV2/wiznew.cpp
+++ b/DKV2/wiznew.cpp
@@ -97,6 +97,8 @@ bool wpNewOrExisting::validatePage()
         setField(pnCity, c.city());
         setField(pnCountry, c.country());
         setField(pnEMail, c.email());
+        setField(pnPhone, c.tel());
+        setField(pnContact, c.contact());
         setField(pnComment, c.comment());
         setField(pnIban, c.iban());
         setField(pnBic, c.bic());
@@ -213,25 +215,39 @@ int wpNewCreditorAddress::nextId() const
  * wizEmailPage - ask e-mail and comment for the new creditor
 */
 const QString pnEMail{qsl("e-mail")};
+const QString pnPhone{qsl("phone")};
+const QString pnContact{qsl("contact")};
 const QString pnComment{qsl("comment")};
 
 wpEmail::wpEmail(QWidget *p) : QWizardPage(p)
 {
     LOG_CALL;
-    setTitle(qsl("E-mail"));
+    setTitle(qsl("Kontaktdaten"));
     subTitleLabel->setWordWrap(true);
-    subTitleLabel->setText(qsl("Gib hier die E-Mail Adresse und eine Anmerkung an.<p>"));
+    subTitleLabel->setText(qsl("Gib hier Telefon, E-Mail und eine Anmerkung an.<p>"));
 
     QLabel *l1 = new QLabel(qsl("E-mail"));
     QLineEdit *leEmail = new QLineEdit;
     leEmail->setToolTip(qsl("Die E-Mail Adresse muss im gültigen Format vorliegen "
                             "(s. https://de.wikipedia.org/wiki/E-Mail-Adresse)."));
     registerField(pnEMail, leEmail);
-    QLabel *l2 = new QLabel(qsl("Anmerkung"));
+
+    QLabel *l2 = new QLabel(qsl("Telefon"));
+    QLineEdit *lePhone = new QLineEdit;
+    lePhone->setToolTip(qsl("Telefonnummer(n)"));
+    registerField(pnPhone, lePhone);
+
+    QLabel *l3 = new QLabel(qsl("Kontakt"));
+    QLineEdit *leContact = new QLineEdit;
+    leContact->setToolTip(qsl("Es ist hilfreich eine Kontaktperson im Projekt "
+                              "anzugeben."));
+    registerField(pnContact, leContact);
+
+    QLabel *l4 = new QLabel(qsl("Anmerkung"));
     QPlainTextEdit *eComment = new QPlainTextEdit;
     registerField(pnComment, eComment, "plainText", "textChanged");
-    eComment->setToolTip(qsl("Es ist hilfreich in der Anmerkung den Kontakt "
-                             "im Projekt oder sonstige Besonderheiten vermerken."));
+    eComment->setToolTip(qsl("Sonstige Besonderheiten hier vermerken."));
+
     QGridLayout *g = new QGridLayout;
     int row = 0;
     g->addWidget(subTitleLabel, row, 0, 1, 4);
@@ -239,15 +255,23 @@ wpEmail::wpEmail(QWidget *p) : QWizardPage(p)
     row += 2;
     g->addWidget(l1, row, 0, 1, 1);
     g->addWidget(leEmail, row, 1, 1, 4);
-
     row++;
     g->addWidget(l2, row, 0, 1, 1);
+    g->addWidget(lePhone, row, 1, 1, 4);
+    row++;
+    g->addWidget(l3, row, 0, 1, 1);
+    g->addWidget(leContact, row, 1, 1, 4);
+    row++;
+    g->addWidget(l4, row, 0, 1, 1);
     g->addWidget(eComment, row, 1, 2, 4);
     g->setColumnStretch(0, 1);
     g->setColumnStretch(1, 2);
     g->setColumnStretch(2, 2);
     g->setColumnStretch(3, 2);
     g->setColumnStretch(4, 2);
+    g->setColumnStretch(5, 2);
+    g->setColumnStretch(6, 2);
+
     setLayout(g);
 }
 bool wpEmail::validatePage()
@@ -266,6 +290,8 @@ bool wpEmail::validatePage()
         }
     }
     setField(pnComment, field(pnComment).toString().trimmed());
+    setField(pnPhone, field(pnPhone).toString().trimmed());
+    setField(pnContact, field(pnContact).toString().trimmed());
     return true;
 }
 int wpEmail::nextId() const
@@ -363,8 +389,10 @@ void wpConfirmCreditor::initializePage()
                                 "<tr><td>Straße:</td><td>%3</td></tr>"
                                 "<tr><td>Plz/Ort:</td><td>%4</td></tr>"
                                 "<tr><td>E-Mail:</td><td>%5<br></td></tr>"
-                                "<tr><td>Kommentar:</td><td><small>%6<small></td></tr>"
-                                "<tr><td>Bankdaten:</td><td><table><tr><td>IBAN:</td><td>%7</td></tr><tr><td>BIC:</td><td>%8<td></tr></table></td></tr></table>")};
+                                "<tr><td>Telefon:</td><td>%6<br></td></tr>"
+                                "<tr><td>Kontakt:</td><td>%7<br></td></tr>"
+                                "<tr><td>Kommentar:</td><td><small>%8<small></td></tr>"
+                                "<tr><td>Bankdaten:</td><td><table><tr><td>IBAN:</td><td>%9</td></tr><tr><td>BIC:</td><td>%10<td></tr></table></td></tr></table>")};
     QString firstn = field(pnFName).toString().isEmpty() ? qsl("(kein Vorname)") : field(pnFName).toString();
     QString lastn = field(pnLName).toString().isEmpty() ? qsl("(kein Nachname)") : field(pnLName).toString();
     QString street = field(pnStreet).toString().isEmpty() ? qsl("(keine Strasse)") : field(pnStreet).toString();
@@ -376,12 +404,14 @@ void wpConfirmCreditor::initializePage()
     if (not country.isEmpty())
         xxx += qsl(" (") + country + qsl(")");
     QString email = field(pnEMail).toString().isEmpty() ? qsl("(keine E-Mail Adresse)") : field(pnEMail).toString();
+    QString phone = field(pnPhone).toString().isEmpty() ? qsl("(keine Telefonnummer)") : field(pnPhone).toString();
+    QString contact = field(pnContact).toString().isEmpty() ? qsl("(kein Kontakt)") : field(pnContact).toString();
     QString comment = field(pnComment).toString().isEmpty() ? qsl("(keine Anmerkung)") : field(pnComment).toString();
     QString iban = field(pnIban).toString().isEmpty() ? qsl("(keine IBAN)") : field(pnIban).toString();
     QString bic = field(pnBic).toString().isEmpty() ? qsl("(keine BIC)") : field(pnBic).toString();
 
     subTitleLabel->setText(creditorSummary.arg(firstn, lastn, street, xxx,
-                                                 email, comment, iban, bic));
+                                                 email, phone, contact, comment, iban, bic));
     wizNew *wiz = qobject_cast<wizNew *>(wizard());
     if (wiz->selectCreateContract)
         cbCreateContract->setChecked(true);
@@ -401,6 +431,8 @@ bool wpConfirmCreditor::validatePage()
     wiz->c_tor.setCity(wiz->field(pnCity).toString());
     wiz->c_tor.setCountry(wiz->field(pnCountry).toString());
     wiz->c_tor.setEmail(wiz->field(pnEMail).toString());
+    wiz->c_tor.setTel(wiz->field(pnPhone).toString());
+    wiz->c_tor.setContact(wiz->field(pnContact).toString());
     wiz->c_tor.setComment(wiz->field(pnComment).toString());
     wiz->c_tor.setIban(wiz->field(pnIban).toString());
     wiz->c_tor.setBic(wiz->field(pnBic).toString());
@@ -491,6 +523,8 @@ void wpLableAndAmount::cleanupPage()
     setField(pnCity, QString());
     setField(pnCountry, QString());
     setField(pnEMail, QString());
+    setField(pnPhone, QString());
+    setField(pnContact, QString());
     setField(pnComment, QString());
     setField(pnIban, QString());
     setField(pnBic, QString());

--- a/DKV2/wiznew.h
+++ b/DKV2/wiznew.h
@@ -86,6 +86,7 @@ private:
 
 extern const QString pnIban;
 extern const QString pnBic;
+extern const QString pnAccount;
 
 struct wpBankAccount : public QWizardPage{
     wpBankAccount(QWidget* p);

--- a/DKV2/wiznew.h
+++ b/DKV2/wiznew.h
@@ -70,6 +70,8 @@ private:
 };
 
 extern const QString pnEMail;
+extern const QString pnPhone;
+extern const QString pnContact;
 extern const QString pnComment;
 
 struct wpEmail : public QWizardPage {

--- a/DKV2/wizterminatecontract.cpp
+++ b/DKV2/wizterminatecontract.cpp
@@ -25,7 +25,7 @@ wpTerminateContract_DatePage::wpTerminateContract_DatePage(QWidget* p) : QWizard
 void wpTerminateContract_DatePage::initializePage()
 {
     wizTerminateContract* wiz = qobject_cast<wizTerminateContract*>(wizard());
-    QString creditorName =executeSingleValueSql(qsl("Vorname || ' ' || Nachname"), qsl("Kreditoren"), qsl("id=") + QString::number(wiz->cont.creditorId())).toString();
+    QString creditorName =executeSingleValueSql(qsl("IFNULL(Vorname || ' ', '') || Nachname"), qsl("Kreditoren"), qsl("id=") + QString::number(wiz->cont.creditorId())).toString();
     QString Kennung =wiz->cont.label();
     QString subt {qsl("Mit dieser Dialogfolge kannst Du den Vertrag <p><b>%1</b> von <b>%2</b><p> beenden.<p>"
                 "Gib das Datum an, zu dem der Vertrag ausgezahlt wird. "

--- a/DKV2/wizterminatecontract.cpp
+++ b/DKV2/wizterminatecontract.cpp
@@ -37,10 +37,11 @@ void wpTerminateContract_DatePage::initializePage()
 bool wpTerminateContract_DatePage::validatePage()
 {
     wizTerminateContract* wiz = qobject_cast<wizTerminateContract*>(wizard());
-    if( field(qsl("date")).toDate() >= wiz->cont.latestBooking().date)
+    QDate lastB =wiz->cont.latestBooking ().date;
+    if( field(qsl("date")).toDate() >= lastB)
         return true;
     QString msg (qsl("Das Vertragsende muss nach der letzten Buchung des Vertrags am %1 sein"));
-    msg = msg.arg(wiz->cont.latestBooking().date.toString(qsl("dd.MM.yyyy")));
+    msg = msg.arg(lastB.toString(qsl("dd.MM.yyyy")));
     QMessageBox::information(this, qsl("Ungültiges Datum"), msg);
     return false;
 }

--- a/TESTS/test_creditor.cpp
+++ b/TESTS/test_creditor.cpp
@@ -41,6 +41,7 @@ void test_creditor::test_createCreditor()
     c.setComment("bester DK Geber");
     c.setIban("DE02120300000000202051");
     c.setBic("BYLADEM1001");
+    c.setAccount("80123");
     QVERIFY2(0 <= c.save(), "creating creditor failed");
     QCOMPARE(tableRecordCount("Kreditoren"), 1);
 }

--- a/TESTS/test_creditor.cpp
+++ b/TESTS/test_creditor.cpp
@@ -36,6 +36,8 @@ void test_creditor::test_createCreditor()
     c.setPostalCode("68205");
     c.setCity("Mannheim");
     c.setEmail("holger.mairon@test.de");
+    c.setTel("+49 123 56789012");
+    c.setContact("Holger selbst");
     c.setComment("bester DK Geber");
     c.setIban("DE02120300000000202051");
     c.setBic("BYLADEM1001");

--- a/TESTS/test_main.cpp
+++ b/TESTS/test_main.cpp
@@ -68,8 +68,11 @@ int main(int argc, char *argv[])
     srand(time(0));
     std::random_shuffle(tests.begin(), tests.end());
 
-    for( auto test: tests){
-        ASSERT_TEST(test);
+    {
+        dbgTimer timer("overall test time");
+        for( auto test: tests){
+            ASSERT_TEST(test);
+        }
     }
 
     if( errCount == 1) qDebug() << "\n>>>   There was an error   <<< ";


### PR DESCRIPTION
SQL statements are changed to handle empty first name (Vorname).
Display last name (Nachname) only if the combination 'Nachname, Vorname' is NULL.