### PR TITLE
Make Linux build Great Again 

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -25,6 +25,8 @@ jobs:
       run: sudo apt-get install libfuse2
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
+    - name: Add missing libraries
+      run: sudo apt-get libxkbcommon-x11-0
     - name: Build and package for Linux
       run: ./dist_linux.sh
     - name: Save artificat

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -18,9 +18,9 @@ jobs:
     - name: Check out
       uses: actions/checkout@v3
     - name: Get linuxdeployqt
-      run:  wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/5/linuxdeployqt-5-x86_64.AppImage"
+      run:  wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
     - name: Make linuxdeployqt executable
-      run: chmod a+x linuxdeployqt-5-x86_64.AppImage
+      run: chmod a+x linuxdeployqt-continuous-x86_64.AppImage
     - name: Install libfuse2
       run: sudo apt-get install libfuse2
     - name: Install Qt

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
     - name: Add missing libraries
-      run: sudo apt-get libxkbcommon-x11-0
+      run: sudo apt-get install libxkbcommon-x11-0
     - name: Build and package for Linux
       run: ./dist_linux.sh
     - name: Save artificat

--- a/dist_linux.sh
+++ b/dist_linux.sh
@@ -62,7 +62,8 @@ unset LD_LIBRARY_PATH # Remove too old Qt from the search path
 #LINUXDEPLOYQT_OPTS=-unsupported-bundle-everything
 LINUXDEPLOYQT_OPTS=-unsupported-allow-new-glibc
 # PATH=${QTDIR}/bin:${PATH} ${LINUXDEPLOYQT} app/DKV2 -bundle-non-qt-libs ${LINUXDEPLOYQT_OPTS}
-EXTRA_PLUGINS="platforms/libqxcb.so,platformthemes/libqgtk3.so,styles/libqgtk3style.so"
+# EXTRA_PLUGINS="platforms/libqxcb.so,platformthemes/libqgtk3.so,styles/libqgtk3style.so"
+EXTRA_PLUGINS="platforms/libqxcb.so,platformthemes/libqgtk3.so"
 PATH=${QTDIR}/bin:${PATH} ${LINUXDEPLOYQT} app/DKV2 \
 	-extra-plugins=${EXTRA_PLUGINS} \
 	-appimage ${LINUXDEPLOYQT_OPTS}

--- a/dist_linux.sh
+++ b/dist_linux.sh
@@ -28,7 +28,7 @@ VERSION=`git describe --tags 2> /dev/null || echo $GIT_VERSION`
 
 LINUXDEPLOYQT="linuxdeployqt"
 if ! command -v $LINUXDEPLOYQT &> /dev/null; then
-	LINUXDEPLOYQT=`pwd`/linuxdeployqt-5-x86_64.AppImage
+	LINUXDEPLOYQT=`pwd`/linuxdeployqt-continuous-x86_64.AppImage
 fi
 
 echo "Building with QTDIR: \`${QTDIR}\`"
@@ -36,7 +36,7 @@ echo "Building with QTDIR: \`${QTDIR}\`"
 ##### download linuxdeployqt
 
 if [ ! -f $LINUXDEPLOYQT ]; then
-	curl -o "$LINUXDEPLOYQT" "https://github.com/probonopd/linuxdeployqt/releases/download/5/linuxdeployqt-5-x86_64.AppImage"
+	curl -o "$LINUXDEPLOYQT" "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
 fi
 
 ##### build #####

--- a/dist_linux.sh
+++ b/dist_linux.sh
@@ -59,7 +59,8 @@ mv ${BUILDDIR}/DKV2 .
 popd
 
 unset LD_LIBRARY_PATH # Remove too old Qt from the search path
-# LINUXDEPLOYQT_OPTS=-unsupported-bundle-everything
+#LINUXDEPLOYQT_OPTS=-unsupported-bundle-everything
+LINUXDEPLOYQT_OPTS=-unsupported-allow-new-glibc
 # PATH=${QTDIR}/bin:${PATH} ${LINUXDEPLOYQT} app/DKV2 -bundle-non-qt-libs ${LINUXDEPLOYQT_OPTS}
 EXTRA_PLUGINS="platforms/libqxcb.so,platformthemes/libqgtk3.so,styles/libqgtk3style.so"
 PATH=${QTDIR}/bin:${PATH} ${LINUXDEPLOYQT} app/DKV2 \


### PR DESCRIPTION
For some reason (maybe Debian packaging issues) the linuxdeployqt script did not provide the library libxkbcommon-x11.
After adding this in build_linux.yml the build works again.
